### PR TITLE
Add compiler skeleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,32 +9,49 @@ SRC_DIR = ./compiler
 BUILD_DIR = ./build
 BIN_DIR = ./bin
 
+MAIN_SRC = $(SRC_DIR)/main.cpp
+
 LEXER_SRC = $(SRC_DIR)/lexer/*.cpp
 PARSER_SRC = $(SRC_DIR)/parser/*.cpp
 AST_SRC = $(SRC_DIR)/ast/*.cpp
 CODEGEN_SRC = $(SRC_DIR)/codegen/*.cpp
 UTILS_SRC = $(SRC_DIR)/utils/*.cpp
 
-OBJS = $(BUILD_DIR)/lexer.o $(BUILD_DIR)/parser.o $(BUILD_DIR)/ast.o $(BUILD_DIR)/codegen.o $(BUILD_DIR)/utils.o
+OBJS = $(BUILD_DIR)/lexer.o \
+       $(BUILD_DIR)/parser.o \
+       $(BUILD_DIR)/ast.o \
+       $(BUILD_DIR)/codegen.o \
+       $(BUILD_DIR)/utils.o \
+       $(BUILD_DIR)/main.o
 
 all: $(BIN_DIR)/aymc
 
 $(BIN_DIR)/aymc: $(OBJS)
+	mkdir -p $(BIN_DIR)
 	$(CXX) $(CXXFLAGS) -o $@ $^
 
 $(BUILD_DIR)/lexer.o: $(LEXER_SRC)
+	mkdir -p $(BUILD_DIR)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(BUILD_DIR)/parser.o: $(PARSER_SRC)
+	mkdir -p $(BUILD_DIR)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(BUILD_DIR)/ast.o: $(AST_SRC)
+	mkdir -p $(BUILD_DIR)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(BUILD_DIR)/codegen.o: $(CODEGEN_SRC)
+	mkdir -p $(BUILD_DIR)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(BUILD_DIR)/utils.o: $(UTILS_SRC)
+	mkdir -p $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/main.o: $(MAIN_SRC)
+	mkdir -p $(BUILD_DIR)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 clean:

--- a/compiler/ast/ast.cpp
+++ b/compiler/ast/ast.cpp
@@ -1,0 +1,7 @@
+#include "ast.h"
+
+namespace aym {
+
+// Placeholder for AST implementations
+
+} // namespace aym

--- a/compiler/ast/ast.h
+++ b/compiler/ast/ast.h
@@ -1,0 +1,13 @@
+#ifndef AYM_AST_H
+#define AYM_AST_H
+
+namespace aym {
+
+class Node {
+public:
+    virtual ~Node() = default;
+};
+
+} // namespace aym
+
+#endif // AYM_AST_H

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1,0 +1,10 @@
+#include "codegen.h"
+#include <iostream>
+
+namespace aym {
+
+void CodeGenerator::generate() {
+    std::cout << "[CodeGenerator] Placeholder" << std::endl;
+}
+
+} // namespace aym

--- a/compiler/codegen/codegen.h
+++ b/compiler/codegen/codegen.h
@@ -1,0 +1,13 @@
+#ifndef AYM_CODEGEN_H
+#define AYM_CODEGEN_H
+
+namespace aym {
+
+class CodeGenerator {
+public:
+    void generate();
+};
+
+} // namespace aym
+
+#endif // AYM_CODEGEN_H

--- a/compiler/lexer/lexer.cpp
+++ b/compiler/lexer/lexer.cpp
@@ -1,0 +1,19 @@
+#include "lexer.h"
+#include <sstream>
+
+namespace aym {
+
+Lexer::Lexer(const std::string &source) : src(source) {}
+
+std::vector<Token> Lexer::tokenize() {
+    std::vector<Token> tokens;
+    std::istringstream iss(src);
+    std::string word;
+    while (iss >> word) {
+        tokens.push_back({TokenType::Identifier, word});
+    }
+    tokens.push_back({TokenType::EndOfFile, ""});
+    return tokens;
+}
+
+} // namespace aym

--- a/compiler/lexer/lexer.h
+++ b/compiler/lexer/lexer.h
@@ -1,0 +1,31 @@
+#ifndef AYM_LEXER_H
+#define AYM_LEXER_H
+
+#include <string>
+#include <vector>
+
+namespace aym {
+
+enum class TokenType {
+    Identifier,
+    Number,
+    String,
+    EndOfFile
+};
+
+struct Token {
+    TokenType type;
+    std::string text;
+};
+
+class Lexer {
+public:
+    explicit Lexer(const std::string &source);
+    std::vector<Token> tokenize();
+private:
+    std::string src;
+};
+
+} // namespace aym
+
+#endif // AYM_LEXER_H

--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -1,0 +1,24 @@
+#include "lexer/lexer.h"
+#include "parser/parser.h"
+#include "codegen/codegen.h"
+#include "utils/utils.h"
+#include <iostream>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "Uso: aymc <archivo.aym>" << std::endl;
+        return 1;
+    }
+
+    std::string source = aym::readFile(argv[1]);
+    aym::Lexer lexer(source);
+    auto tokens = lexer.tokenize();
+
+    aym::Parser parser(tokens);
+    parser.parse();
+
+    aym::CodeGenerator cg;
+    cg.generate();
+
+    return 0;
+}

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -1,0 +1,13 @@
+#include "parser.h"
+
+namespace aym {
+
+Parser::Parser(const std::vector<Token>& tokens) : tokens(tokens) {}
+
+void Parser::parse() {
+    for (const auto& token : tokens) {
+        std::cout << "TOKEN: " << token.text << std::endl;
+    }
+}
+
+} // namespace aym

--- a/compiler/parser/parser.h
+++ b/compiler/parser/parser.h
@@ -1,0 +1,20 @@
+#ifndef AYM_PARSER_H
+#define AYM_PARSER_H
+
+#include <vector>
+#include <iostream>
+#include "../lexer/lexer.h"
+
+namespace aym {
+
+class Parser {
+public:
+    explicit Parser(const std::vector<Token>& tokens);
+    void parse();
+private:
+    std::vector<Token> tokens;
+};
+
+} // namespace aym
+
+#endif // AYM_PARSER_H

--- a/compiler/utils/utils.cpp
+++ b/compiler/utils/utils.cpp
@@ -1,0 +1,14 @@
+#include "utils.h"
+#include <fstream>
+#include <sstream>
+
+namespace aym {
+
+std::string readFile(const std::string &path) {
+    std::ifstream file(path);
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+}
+
+} // namespace aym

--- a/compiler/utils/utils.h
+++ b/compiler/utils/utils.h
@@ -1,0 +1,12 @@
+#ifndef AYM_UTILS_H
+#define AYM_UTILS_H
+
+#include <string>
+
+namespace aym {
+
+std::string readFile(const std::string &path);
+
+} // namespace aym
+
+#endif // AYM_UTILS_H

--- a/samples/hola.aym
+++ b/samples/hola.aym
@@ -1,0 +1,7 @@
+yatiyawi Hola:
+    lurayiri ninchaña():
+        willt’aña("Kamisaraki!");
+
+jaqichawi:
+    P = Hola()
+    P.ninchaña()


### PR DESCRIPTION
## Summary
- implement basic C++17 skeleton for the `aymc` compiler
- add placeholder lexer, parser, AST, codegen and utils modules
- add initial `main.cpp` that tokenizes, parses and emits a placeholder message
- update `Makefile` to build the new sources and create output directories
- include `samples/hola.aym` example

## Testing
- `make`
- `./bin/aymc samples/hola.aym`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_684b1187d4048327a2c5fb5769f8bf42