### PR TITLE
Add basic type system, control flow and CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ $ ./build/out
 11
 ```
 
-<<<<<<< codex/implementar-operaciones-básicas-en-compilador
 ```bash
 $ ./bin/aymc samples/condloop.aym
 $ ./build/out
@@ -120,8 +119,6 @@ inicio
 1
 ```
 
-=======
->>>>>>> main
 ---
 
 ## 🧰 Tecnologías y Herramientas
@@ -192,7 +189,4 @@ Este proyecto es abierto a toda colaboración. Nos interesa especialmente:
 
 > ✨ ¡Únete al desarrollo y forma parte del cambio tecnológico-cultural!
 
-```
 
-¿Te gustaría que genere también un diagrama de arquitectura del compilador?
-```

--- a/compiler/ast/ast.h
+++ b/compiler/ast/ast.h
@@ -96,13 +96,75 @@ public:
 class IfStmt : public Stmt {
 public:
     IfStmt(std::unique_ptr<Expr> cond,
-           std::unique_ptr<BlockStmt> body)
-        : condition(std::move(cond)), thenBlock(std::move(body)) {}
+           std::unique_ptr<BlockStmt> thenBlk,
+           std::unique_ptr<BlockStmt> elseBlk = nullptr)
+        : condition(std::move(cond)), thenBlock(std::move(thenBlk)),
+          elseBlock(std::move(elseBlk)) {}
     Expr *getCondition() const { return condition.get(); }
     BlockStmt *getThen() const { return thenBlock.get(); }
+    BlockStmt *getElse() const { return elseBlock.get(); }
 private:
     std::unique_ptr<Expr> condition;
     std::unique_ptr<BlockStmt> thenBlock;
+    std::unique_ptr<BlockStmt> elseBlock;
+};
+
+class ForStmt : public Stmt {
+public:
+    ForStmt(std::unique_ptr<Stmt> init,
+            std::unique_ptr<Expr> cond,
+            std::unique_ptr<Stmt> post,
+            std::unique_ptr<BlockStmt> body)
+        : initStmt(std::move(init)), condition(std::move(cond)),
+          postStmt(std::move(post)), body(std::move(body)) {}
+    Stmt *getInit() const { return initStmt.get(); }
+    Expr *getCondition() const { return condition.get(); }
+    Stmt *getPost() const { return postStmt.get(); }
+    BlockStmt *getBody() const { return body.get(); }
+private:
+    std::unique_ptr<Stmt> initStmt;
+    std::unique_ptr<Expr> condition;
+    std::unique_ptr<Stmt> postStmt;
+    std::unique_ptr<BlockStmt> body;
+};
+
+class BreakStmt : public Stmt {};
+class ContinueStmt : public Stmt {};
+
+class ReturnStmt : public Stmt {
+public:
+    explicit ReturnStmt(std::unique_ptr<Expr> v) : value(std::move(v)) {}
+    Expr *getValue() const { return value.get(); }
+private:
+    std::unique_ptr<Expr> value;
+};
+
+class VarDeclStmt : public Stmt {
+public:
+    VarDeclStmt(std::string t, std::string n, std::unique_ptr<Expr> i)
+        : type(std::move(t)), name(std::move(n)), init(std::move(i)) {}
+    const std::string &getType() const { return type; }
+    const std::string &getName() const { return name; }
+    Expr *getInit() const { return init.get(); }
+private:
+    std::string type;
+    std::string name;
+    std::unique_ptr<Expr> init;
+};
+
+class FunctionStmt : public Stmt {
+public:
+    FunctionStmt(std::string n,
+                 std::vector<std::string> p,
+                 std::unique_ptr<BlockStmt> b)
+        : name(std::move(n)), params(std::move(p)), body(std::move(b)) {}
+    const std::string &getName() const { return name; }
+    const std::vector<std::string> &getParams() const { return params; }
+    BlockStmt *getBody() const { return body.get(); }
+private:
+    std::string name;
+    std::vector<std::string> params;
+    std::unique_ptr<BlockStmt> body;
 };
 
 class WhileStmt : public Stmt {

--- a/compiler/lexer/lexer.cpp
+++ b/compiler/lexer/lexer.cpp
@@ -28,8 +28,28 @@ std::vector<Token> Lexer::tokenize() {
                 tokens.push_back({TokenType::KeywordPrint, word});
             } else if (word == "si") {
                 tokens.push_back({TokenType::KeywordIf, word});
+            } else if (word == "sino") {
+                tokens.push_back({TokenType::KeywordElse, word});
             } else if (word == "mientras") {
                 tokens.push_back({TokenType::KeywordWhile, word});
+            } else if (word == "para") {
+                tokens.push_back({TokenType::KeywordFor, word});
+            } else if (word == "break") {
+                tokens.push_back({TokenType::KeywordBreak, word});
+            } else if (word == "continue") {
+                tokens.push_back({TokenType::KeywordContinue, word});
+            } else if (word == "func") {
+                tokens.push_back({TokenType::KeywordFunc, word});
+            } else if (word == "retorna") {
+                tokens.push_back({TokenType::KeywordReturn, word});
+            } else if (word == "int") {
+                tokens.push_back({TokenType::KeywordInt, word});
+            } else if (word == "float") {
+                tokens.push_back({TokenType::KeywordFloat, word});
+            } else if (word == "bool") {
+                tokens.push_back({TokenType::KeywordBool, word});
+            } else if (word == "string") {
+                tokens.push_back({TokenType::KeywordString, word});
             } else {
                 tokens.push_back({TokenType::Identifier, word});
             }

--- a/compiler/lexer/lexer.h
+++ b/compiler/lexer/lexer.h
@@ -14,12 +14,9 @@ enum class TokenType {
     Minus,
     Star,
     Slash,
-<<<<<<< codex/implementar-operaciones-básicas-en-compilador
     Equal,
     LBrace,
     RBrace,
-=======
->>>>>>> main
     LParen,
     RParen,
     Colon,
@@ -27,7 +24,17 @@ enum class TokenType {
     Semicolon,
     KeywordPrint,
     KeywordIf,
+    KeywordElse,
     KeywordWhile,
+    KeywordFor,
+    KeywordBreak,
+    KeywordContinue,
+    KeywordFunc,
+    KeywordReturn,
+    KeywordInt,
+    KeywordFloat,
+    KeywordBool,
+    KeywordString,
     EndOfFile
 };
 

--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -5,35 +5,48 @@
 #include "semantic/semantic.h"
 #include "utils/error.h"
 #include <iostream>
+#include <vector>
 #include <string>
 
 int main(int argc, char** argv) {
-    std::string input;
+    std::vector<std::string> inputs;
     std::string output = "build/out";
+    bool debug = false;
+    bool dumpAst = false;
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
         if (arg == "-h" || arg == "--help") {
-            std::cout << "Uso: aymc [-o salida] archivo.aym" << std::endl;
+            std::cout << "Uso: aymc [opciones] archivo.aym ..." << std::endl;
             return 0;
         } else if (arg == "-o" && i + 1 < argc) {
             output = argv[++i];
+        } else if (arg == "--debug") {
+            debug = true;
+        } else if (arg == "--dump-ast") {
+            dumpAst = true;
         } else {
-            input = arg;
+            inputs.push_back(arg);
         }
     }
 
-    if (input.empty()) {
+    if (inputs.empty()) {
         aym::error("Se requiere un archivo de entrada");
         return 1;
     }
 
-    std::string source = aym::readFile(input);
+    std::string source;
+    for (const auto &in : inputs) source += aym::readFile(in) + "\n";
     aym::Lexer lexer(source);
     auto tokens = lexer.tokenize();
+    if (debug) {
+        for (const auto &t : tokens) std::cout << static_cast<int>(t.type) << ":" << t.text << std::endl;
+    }
 
     aym::Parser parser(tokens);
     auto nodes = parser.parse();
-
+    if (dumpAst) {
+        std::cout << "AST nodos: " << nodes.size() << std::endl;
+    }
     aym::SemanticAnalyzer sem;
     sem.analyze(nodes);
 

--- a/compiler/semantic/semantic.h
+++ b/compiler/semantic/semantic.h
@@ -13,9 +13,9 @@ public:
     void analyze(const std::vector<std::unique_ptr<Node>> &nodes);
 
 private:
-    std::unordered_map<std::string, bool> symbols;
+    std::unordered_map<std::string, std::string> symbols;
     void analyzeStmt(const Stmt *stmt);
-    void analyzeExpr(const Expr *expr);
+    std::string analyzeExpr(const Expr *expr);
 };
 
 } // namespace aym

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,3 +1,4 @@
 # Runtime
 
 Este directorio contiene la biblioteca estándar mínima para el lenguaje `aym`. Por ahora se apoya en la función `printf` de la libc para realizar operaciones de entrada y salida básicas.
+\nSe incluye la función `leer_linea` para lectura básica desde entrada estándar.

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <string.h>
+
+void leer_linea(char *buf, int size) {
+    if (fgets(buf, size, stdin)) {
+        size_t len = strlen(buf);
+        if (len && buf[len-1] == '\n') buf[len-1] = '\0';
+    } else {
+        if (size) buf[0] = '\0';
+    }
+}
+

--- a/samples/else.aym
+++ b/samples/else.aym
@@ -1,0 +1,6 @@
+si (0) {
+    willt’aña("then");
+} sino {
+    willt’aña("else");
+}
+

--- a/samples/for.aym
+++ b/samples/for.aym
@@ -1,0 +1,5 @@
+contador = 3;
+para (contador = 3; contador; contador = contador - 1;) {
+    willt’aña(contador);
+}
+

--- a/samples/func.aym
+++ b/samples/func.aym
@@ -1,0 +1,5 @@
+func saludo(nombre) {
+    willt’aña(nombre);
+}
+
+saludo("Kamisaraki!");

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+make >/dev/null
+./bin/aymc samples/hola.aym >/dev/null
+./build/out | grep -q Kamisaraki


### PR DESCRIPTION
## Summary
- implement simple typed variables, for loops and else blocks
- extend AST with declarations, loops, breaks, returns and functions
- improve lexer/parser/semantic analyzer
- add CLI flags for `--debug` and `--dump-ast`
- provide minimal runtime function `leer_linea`
- add samples and a basic test script

## Testing
- `make >/dev/null`
- `bash tests/basic.sh`


------
https://chatgpt.com/codex/tasks/task_e_684b801ffa0c8327a0c12e81958309f7