### PR TITLE
Fix runtime README formatting and remove duplicate code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,6 @@ y = x * 2 + 3;
 willt’aña(y);
 ```
 
-### `ops.aym`
-```aymara
-willt’aña(3 + 4 * 2);
-```
 
 ### Compilación y Ejecución
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,4 +1,5 @@
 # Runtime
 
 Este directorio contiene la biblioteca estándar mínima para el lenguaje `aym`. Por ahora se apoya en la función `printf` de la libc para realizar operaciones de entrada y salida básicas.
-\nSe incluye la función `leer_linea` para lectura básica desde entrada estándar.
+
+Se incluye la función `leer_linea` para lectura básica desde entrada estándar.


### PR DESCRIPTION
## Summary
- remove redundant `ops.aym` snippet
- clean stray newline in `runtime/README.md`

## Testing
- `bash tests/basic.sh`


------
https://chatgpt.com/codex/tasks/task_e_684b893e37fc8327a96e7e89cf6dabc3