### PR TITLE
Enhance semantic analyzer for loops, functions and calls

### DIFF
--- a/compiler/semantic/semantic.cpp
+++ b/compiler/semantic/semantic.cpp
@@ -4,6 +4,7 @@
 namespace aym {
 
 void SemanticAnalyzer::analyze(const std::vector<std::unique_ptr<Node>> &nodes) {
+    functions["willt’aña"] = 1; // built-in print function
     for (const auto &n : nodes) {
         analyzeStmt(static_cast<const Stmt *>(n.get()));
     }
@@ -44,18 +45,44 @@ void SemanticAnalyzer::analyzeStmt(const Stmt *stmt) {
     }
     if (auto *w = dynamic_cast<const WhileStmt *>(stmt)) {
         analyzeExpr(w->getCondition());
+        ++loopDepth;
         analyzeStmt(w->getBody());
+        --loopDepth;
         return;
     }
     if (auto *f = dynamic_cast<const ForStmt *>(stmt)) {
+        ++loopDepth;
         analyzeStmt(f->getInit());
         analyzeExpr(f->getCondition());
         analyzeStmt(f->getPost());
         analyzeStmt(f->getBody());
+        --loopDepth;
         return;
     }
     if (auto *fn = dynamic_cast<const FunctionStmt *>(stmt)) {
+        functions[fn->getName()] = fn->getParams().size();
+        ++functionDepth;
         analyzeStmt(fn->getBody());
+        --functionDepth;
+        return;
+    }
+    if (dynamic_cast<const BreakStmt *>(stmt)) {
+        if (loopDepth == 0) {
+            std::cerr << "Error: 'break' fuera de un ciclo" << std::endl;
+        }
+        return;
+    }
+    if (dynamic_cast<const ContinueStmt *>(stmt)) {
+        if (loopDepth == 0) {
+            std::cerr << "Error: 'continue' fuera de un ciclo" << std::endl;
+        }
+        return;
+    }
+    if (auto *r = dynamic_cast<const ReturnStmt *>(stmt)) {
+        if (functionDepth == 0) {
+            std::cerr << "Error: 'return' fuera de una funcion" << std::endl;
+        }
+        if (r->getValue()) analyzeExpr(r->getValue());
         return;
     }
 }
@@ -83,6 +110,12 @@ std::string SemanticAnalyzer::analyzeExpr(const Expr *expr) {
         return l;
     }
     if (auto *c = dynamic_cast<const CallExpr *>(expr)) {
+        auto it = functions.find(c->getName());
+        if (it == functions.end()) {
+            std::cerr << "Error: funcion '" << c->getName() << "' no declarada" << std::endl;
+        } else if (c->getArgs().size() != it->second) {
+            std::cerr << "Error: numero incorrecto de argumentos en llamada a '" << c->getName() << "'" << std::endl;
+        }
         for (const auto &arg : c->getArgs()) analyzeExpr(arg.get());
         return "int";
     }

--- a/compiler/semantic/semantic.h
+++ b/compiler/semantic/semantic.h
@@ -14,6 +14,9 @@ public:
 
 private:
     std::unordered_map<std::string, std::string> symbols;
+    std::unordered_map<std::string, size_t> functions;
+    int loopDepth = 0;
+    int functionDepth = 0;
     void analyzeStmt(const Stmt *stmt);
     std::string analyzeExpr(const Expr *expr);
 };


### PR DESCRIPTION
## Summary
- track loop and function depth in the semantic analyzer
- reject break/continue outside of loops
- reject return outside of a function
- validate that called functions exist and argument counts match

## Testing
- `make`
- `./tests/basic.sh`


------
https://chatgpt.com/codex/tasks/task_e_684b8942b818832784cd015dce8328c4