### PR TITLE
Implement AST visitor pattern

### DIFF
--- a/compiler/ast/ast.h
+++ b/compiler/ast/ast.h
@@ -7,9 +7,56 @@
 
 namespace aym {
 
+class NumberExpr;
+class StringExpr;
+class VariableExpr;
+class BinaryExpr;
+class UnaryExpr;
+class CallExpr;
+class PrintStmt;
+class ExprStmt;
+class AssignStmt;
+class BlockStmt;
+class IfStmt;
+class ForStmt;
+class BreakStmt;
+class ContinueStmt;
+class ReturnStmt;
+class VarDeclStmt;
+class FunctionStmt;
+class WhileStmt;
+class DoWhileStmt;
+class SwitchStmt;
+
+class ASTVisitor {
+public:
+    virtual ~ASTVisitor() = default;
+    virtual void visit(NumberExpr &) = 0;
+    virtual void visit(StringExpr &) = 0;
+    virtual void visit(VariableExpr &) = 0;
+    virtual void visit(BinaryExpr &) = 0;
+    virtual void visit(UnaryExpr &) = 0;
+    virtual void visit(CallExpr &) = 0;
+    virtual void visit(PrintStmt &) = 0;
+    virtual void visit(ExprStmt &) = 0;
+    virtual void visit(AssignStmt &) = 0;
+    virtual void visit(BlockStmt &) = 0;
+    virtual void visit(IfStmt &) = 0;
+    virtual void visit(ForStmt &) = 0;
+    virtual void visit(BreakStmt &) = 0;
+    virtual void visit(ContinueStmt &) = 0;
+    virtual void visit(ReturnStmt &) = 0;
+    virtual void visit(VarDeclStmt &) = 0;
+    virtual void visit(FunctionStmt &) = 0;
+    virtual void visit(WhileStmt &) = 0;
+    virtual void visit(DoWhileStmt &) = 0;
+    virtual void visit(SwitchStmt &) = 0;
+};
+
 class Node {
 public:
     virtual ~Node() = default;
+    virtual void accept(ASTVisitor &) = 0;
 };
 
 class Expr : public Node {
@@ -22,6 +69,7 @@ class NumberExpr : public Expr {
 public:
     explicit NumberExpr(long v) : value(v) {}
     long getValue() const { return value; }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     long value;
 };
@@ -30,6 +78,7 @@ class StringExpr : public Expr {
 public:
     explicit StringExpr(const std::string &v) : value(v) {}
     const std::string &getValue() const { return value; }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     std::string value;
 };
@@ -38,6 +87,7 @@ class VariableExpr : public Expr {
 public:
     explicit VariableExpr(const std::string &n) : name(n) {}
     const std::string &getName() const { return name; }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     std::string name;
 };
@@ -51,6 +101,7 @@ public:
     char getOp() const { return oper; }
     Expr *getLeft() const { return left.get(); }
     Expr *getRight() const { return right.get(); }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     char oper;
     std::unique_ptr<Expr> left, right;
@@ -61,6 +112,7 @@ public:
     UnaryExpr(char o, std::unique_ptr<Expr> e) : op(o), expr(std::move(e)) {}
     char getOp() const { return op; }
     Expr *getExpr() const { return expr.get(); }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     char op;
     std::unique_ptr<Expr> expr;
@@ -73,6 +125,7 @@ public:
         : name(std::move(callee)), arguments(std::move(args)) {}
     const std::string &getName() const { return name; }
     const std::vector<std::unique_ptr<Expr>> &getArgs() const { return arguments; }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     std::string name;
     std::vector<std::unique_ptr<Expr>> arguments;
@@ -83,6 +136,7 @@ public:
     explicit PrintStmt(std::unique_ptr<Expr> expr)
         : expression(std::move(expr)) {}
     Expr *getExpr() const { return expression.get(); }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     std::unique_ptr<Expr> expression;
 };
@@ -92,6 +146,7 @@ public:
     explicit ExprStmt(std::unique_ptr<Expr> e)
         : expression(std::move(e)) {}
     Expr *getExpr() const { return expression.get(); }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     std::unique_ptr<Expr> expression;
 };
@@ -102,6 +157,7 @@ public:
         : name(std::move(n)), value(std::move(v)) {}
     const std::string &getName() const { return name; }
     Expr *getValue() const { return value.get(); }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     std::string name;
     std::unique_ptr<Expr> value;
@@ -110,6 +166,7 @@ private:
 class BlockStmt : public Stmt {
 public:
     std::vector<std::unique_ptr<Stmt>> statements;
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 };
 
 class IfStmt : public Stmt {
@@ -122,6 +179,7 @@ public:
     Expr *getCondition() const { return condition.get(); }
     BlockStmt *getThen() const { return thenBlock.get(); }
     BlockStmt *getElse() const { return elseBlock.get(); }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     std::unique_ptr<Expr> condition;
     std::unique_ptr<BlockStmt> thenBlock;
@@ -140,6 +198,7 @@ public:
     Expr *getCondition() const { return condition.get(); }
     Stmt *getPost() const { return postStmt.get(); }
     BlockStmt *getBody() const { return body.get(); }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     std::unique_ptr<Stmt> initStmt;
     std::unique_ptr<Expr> condition;
@@ -147,13 +206,14 @@ private:
     std::unique_ptr<BlockStmt> body;
 };
 
-class BreakStmt : public Stmt {};
-class ContinueStmt : public Stmt {};
+class BreakStmt : public Stmt { public: void accept(ASTVisitor &v) override { v.visit(*this); } };
+class ContinueStmt : public Stmt { public: void accept(ASTVisitor &v) override { v.visit(*this); } };
 
 class ReturnStmt : public Stmt {
 public:
     explicit ReturnStmt(std::unique_ptr<Expr> v) : value(std::move(v)) {}
     Expr *getValue() const { return value.get(); }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     std::unique_ptr<Expr> value;
 };
@@ -165,6 +225,7 @@ public:
     const std::string &getType() const { return type; }
     const std::string &getName() const { return name; }
     Expr *getInit() const { return init.get(); }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     std::string type;
     std::string name;
@@ -180,6 +241,7 @@ public:
     const std::string &getName() const { return name; }
     const std::vector<std::string> &getParams() const { return params; }
     BlockStmt *getBody() const { return body.get(); }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     std::string name;
     std::vector<std::string> params;
@@ -193,6 +255,7 @@ public:
         : condition(std::move(cond)), body(std::move(body)) {}
     Expr *getCondition() const { return condition.get(); }
     BlockStmt *getBody() const { return body.get(); }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     std::unique_ptr<Expr> condition;
     std::unique_ptr<BlockStmt> body;
@@ -205,6 +268,7 @@ public:
         : body(std::move(b)), condition(std::move(cond)) {}
     Expr *getCondition() const { return condition.get(); }
     BlockStmt *getBody() const { return body.get(); }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     std::unique_ptr<BlockStmt> body;
     std::unique_ptr<Expr> condition;
@@ -219,6 +283,7 @@ public:
     Expr *getExpr() const { return expr.get(); }
     const std::vector<std::pair<std::unique_ptr<Expr>, std::unique_ptr<BlockStmt>>> &getCases() const { return cases; }
     BlockStmt *getDefault() const { return defaultCase.get(); }
+    void accept(ASTVisitor &v) override { v.visit(*this); }
 private:
     std::unique_ptr<Expr> expr;
     std::vector<std::pair<std::unique_ptr<Expr>, std::unique_ptr<BlockStmt>>> cases;

--- a/compiler/semantic/semantic.h
+++ b/compiler/semantic/semantic.h
@@ -9,7 +9,7 @@
 
 namespace aym {
 
-class SemanticAnalyzer {
+class SemanticAnalyzer : public ASTVisitor {
 public:
     void analyze(const std::vector<std::unique_ptr<Node>> &nodes);
     const std::unordered_set<std::string> &getGlobals() const { return globals; }
@@ -32,9 +32,30 @@ private:
     bool isDeclared(const std::string &name) const;
     std::string lookup(const std::string &name) const;
 
-    void analyzeStmt(const Stmt *stmt);
-    std::string analyzeExpr(const Expr *expr);
-};
+    std::string currentType;
+    bool lastInputCall = false;
+
+    void visit(NumberExpr &) override;
+    void visit(StringExpr &) override;
+    void visit(VariableExpr &) override;
+    void visit(BinaryExpr &) override;
+    void visit(UnaryExpr &) override;
+    void visit(CallExpr &) override;
+    void visit(PrintStmt &) override;
+    void visit(ExprStmt &) override;
+    void visit(AssignStmt &) override;
+    void visit(BlockStmt &) override;
+    void visit(IfStmt &) override;
+    void visit(ForStmt &) override;
+    void visit(BreakStmt &) override;
+    void visit(ContinueStmt &) override;
+    void visit(ReturnStmt &) override;
+    void visit(VarDeclStmt &) override;
+    void visit(FunctionStmt &) override;
+    void visit(WhileStmt &) override;
+    void visit(DoWhileStmt &) override;
+    void visit(SwitchStmt &) override;
+}; 
 
 } // namespace aym
 


### PR DESCRIPTION
## Summary
- add `ASTVisitor` interface and `accept` methods in AST nodes
- refactor `SemanticAnalyzer` to implement visitor pattern

## Testing
- `make`
- `./tests/basic.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852391f9f10832789099b2ee736e817