### PR TITLE
Add GoogleTest unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,21 @@ OBJS = $(BUILD_DIR)/lexer.o \
        $(BUILD_DIR)/utils.o \
        $(BUILD_DIR)/error.o \
        $(BUILD_DIR)/semantic.o \
-       $(BUILD_DIR)/builtins.o \
-       $(BUILD_DIR)/main.o
+       $(BUILD_DIR)/builtins.o
+
+OBJS_NO_MAIN = $(BUILD_DIR)/lexer.o \
+       $(BUILD_DIR)/parser.o \
+       $(BUILD_DIR)/ast.o \
+       $(BUILD_DIR)/codegen.o \
+       $(BUILD_DIR)/utils.o \
+       $(BUILD_DIR)/error.o \
+       $(BUILD_DIR)/semantic.o \
+       $(BUILD_DIR)/builtins.o
+
+TEST_SRC = tests/unittests/test_compiler.cpp
+TEST_OBJ = $(BUILD_DIR)/test_compiler.o
+
+OBJS += $(BUILD_DIR)/main.o
 
 all: $(BIN_DIR)/aymc
 
@@ -71,6 +84,17 @@ $(BUILD_DIR)/builtins.o: $(BUILTINS_SRC)
 $(BUILD_DIR)/main.o: $(MAIN_SRC)
 	mkdir -p $(BUILD_DIR)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+$(TEST_OBJ): $(TEST_SRC)
+	mkdir -p $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) -I. -c $< -o $@
+
+$(BIN_DIR)/unittests: $(OBJS_NO_MAIN) $(TEST_OBJ)
+	mkdir -p $(BIN_DIR)
+	$(CXX) $(CXXFLAGS) -o $@ $^ -lgtest -lgtest_main -pthread
+
+test: $(BIN_DIR)/unittests
+	$<
 
 clean:
 	rm -rf $(BUILD_DIR)/*.o $(BIN_DIR)/aymc

--- a/tests/unittests/test_compiler.cpp
+++ b/tests/unittests/test_compiler.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+#include "compiler/lexer/lexer.h"
+#include "compiler/parser/parser.h"
+#include "compiler/codegen/codegen.h"
+#include "compiler/ast/ast.h"
+#include <fstream>
+#include <cstdio>
+
+using namespace aym;
+
+TEST(LexerTest, SimpleTokenize) {
+    Lexer lexer("willt’aña(1);");
+    auto tokens = lexer.tokenize();
+    ASSERT_EQ(tokens.size(), 6);
+    EXPECT_EQ(tokens[0].type, TokenType::KeywordPrint);
+    EXPECT_EQ(tokens[1].type, TokenType::LParen);
+    EXPECT_EQ(tokens[2].type, TokenType::Number);
+    EXPECT_EQ(tokens[2].text, "1");
+    EXPECT_EQ(tokens[3].type, TokenType::RParen);
+    EXPECT_EQ(tokens[4].type, TokenType::Semicolon);
+    EXPECT_EQ(tokens[5].type, TokenType::EndOfFile);
+}
+
+TEST(ParserTest, ParsePrintStmt) {
+    Lexer lexer("willt’aña(1);");
+    auto tokens = lexer.tokenize();
+    Parser parser(tokens);
+    auto nodes = parser.parse();
+    ASSERT_FALSE(parser.hasError());
+    ASSERT_EQ(nodes.size(), 1u);
+    auto *printStmt = dynamic_cast<PrintStmt*>(nodes[0].get());
+    ASSERT_NE(printStmt, nullptr);
+    auto *num = dynamic_cast<NumberExpr*>(printStmt->getExpr());
+    ASSERT_NE(num, nullptr);
+    EXPECT_EQ(num->getValue(), 1);
+}
+
+TEST(ParserTest, ExpressionPrecedence) {
+    Lexer lexer("1 + 2 * 3;");
+    auto tokens = lexer.tokenize();
+    Parser parser(tokens);
+    auto nodes = parser.parse();
+    ASSERT_FALSE(parser.hasError());
+    ASSERT_EQ(nodes.size(), 1u);
+    auto *exprStmt = dynamic_cast<ExprStmt*>(nodes[0].get());
+    ASSERT_NE(exprStmt, nullptr);
+    auto *add = dynamic_cast<BinaryExpr*>(exprStmt->getExpr());
+    ASSERT_NE(add, nullptr);
+    EXPECT_EQ(add->getOp(), '+');
+    auto *left = dynamic_cast<NumberExpr*>(add->getLeft());
+    ASSERT_NE(left, nullptr);
+    EXPECT_EQ(left->getValue(), 1);
+    auto *mul = dynamic_cast<BinaryExpr*>(add->getRight());
+    ASSERT_NE(mul, nullptr);
+    EXPECT_EQ(mul->getOp(), '*');
+}
+
+TEST(CodeGenTest, GeneratesAssembly) {
+    std::string src = "willt’aña(\"ok\");";
+    Lexer lexer(src);
+    auto tokens = lexer.tokenize();
+    Parser parser(tokens);
+    auto nodes = parser.parse();
+    ASSERT_FALSE(parser.hasError());
+
+    CodeGenerator cg;
+    cg.generate(nodes, "build/test_output.asm", {}, {}, {});
+
+    std::ifstream in("build/test_output.asm");
+    ASSERT_TRUE(in.is_open());
+    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    in.close();
+    EXPECT_NE(contents.find("ok"), std::string::npos);
+
+    std::remove("build/test_output.asm");
+    std::remove("build/test_output.o");
+    std::remove("bin/test_output");
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- set up `tests/unittests` folder with GoogleTest
- implement Lexer, Parser and basic codegen tests
- extend Makefile with `unittests` binary and `test` target

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68523e7920208327bb545ba9ce1c498f