### PR TITLE
Fix duplicated Makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,6 @@ $(BUILD_DIR)/main.o: $(MAIN_SRC)
 	mkdir -p $(BUILD_DIR)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
-$(BUILD_DIR)/main.o: $(MAIN_SRC)
-	mkdir -p $(BUILD_DIR)
-	$(CXX) $(CXXFLAGS) -c $< -o $@
-
 test: all
 	bash tests/run_tests.sh
 


### PR DESCRIPTION
## Summary
- remove duplicate rule for `$(BUILD_DIR)/main.o`

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685308f86d648327adecd1babb1701d1