### PR TITLE
Improve Windows build compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,10 @@ $ ./bin/aymc --linux samples/hola.aym
 
 ### Uso en Windows
 
-1. Instalar [MinGW-w64](https://www.mingw-w64.org/) y la versión para Windows de `nasm`
+1. Instalar [MinGW-w64](https://www.mingw-w64.org/) (GCC 9 o superior) y la versión para Windows de `nasm`.
 2. Ejecutar `build.bat` para compilar `aymc.exe`.
+   Asegúrate de que `g++ --version` reporte 9 o superior, de lo contrario
+   el encabezado `<filesystem>` no estará disponible.
 3. Compilar un archivo `.aym` con:
 
 ```cmd

--- a/build.bat
+++ b/build.bat
@@ -12,6 +12,8 @@ g++ -std=c++17 -Wall -O2 ^
   compiler\semantic\semantic.cpp ^
   compiler\utils\utils.cpp ^
   compiler\utils\error.cpp ^
+  compiler\interpreter\interpreter.cpp ^
   compiler\main.cpp ^
-  -o bin\aymc.exe
+  -o bin\aymc.exe ^
+  -lstdc++fs
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -4,7 +4,7 @@
 #include <fstream>
 #include <iostream>
 #include <cstdlib>
-#include <filesystem>
+#include "../utils/fs.h"
 #include <unordered_map>
 #include <unordered_set>
 #include <algorithm>
@@ -688,7 +688,6 @@ void CodeGenImpl::emit(const std::vector<std::unique_ptr<Node>> &nodes,
 
     out.close();
 
-    namespace fs = std::filesystem;
     fs::create_directories("build");
     fs::create_directories("bin");
 

--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -10,7 +10,7 @@
 #include <sstream>
 #include <vector>
 #include <string>
-#include <filesystem>
+#include "utils/fs.h"
 
 int main(int argc, char** argv) {
     std::vector<std::string> inputs;
@@ -89,7 +89,6 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    namespace fs = std::filesystem;
     if (!outputProvided) {
         fs::path base = fs::path(inputs[0]).stem();
         output = (fs::path("build") / base).string();

--- a/compiler/utils/fs.h
+++ b/compiler/utils/fs.h
@@ -1,0 +1,15 @@
+#ifndef AYM_FS_H
+#define AYM_FS_H
+
+#if __has_include(<filesystem>)
+  #include <filesystem>
+  namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+  #include <experimental/filesystem>
+  namespace fs = std::experimental::filesystem;
+#else
+  #error "<filesystem> not found"
+#endif
+
+#endif // AYM_FS_H
+


### PR DESCRIPTION
## Summary
- add portable filesystem wrapper
- use wrapper in compiler sources
- link `stdc++fs` in `build.bat`
- add interpreter source to Windows build
- document GCC 9+ requirement for Windows

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6853498493108327a21013de82d03d64