### PR TITLE
Add array utilities and timing to support sample Tetris game

### DIFF
--- a/compiler/builtins/builtins.cpp
+++ b/compiler/builtins/builtins.cpp
@@ -6,7 +6,12 @@ static const std::unordered_map<std::string, BuiltinInfo> builtins = {
     {BUILTIN_PRINT, {1, {}}},
     {BUILTIN_INPUT, {0, {}}},
     {BUILTIN_LENGTH, {1, {Type::String}}},
-    {BUILTIN_RANDOM, {1, {Type::Int}}}
+    {BUILTIN_RANDOM, {1, {Type::Int}}},
+    {BUILTIN_SLEEP, {1, {Type::Int}}},
+    {BUILTIN_ARRAY_NEW, {1, {Type::Int}}},
+    {BUILTIN_ARRAY_GET, {2, {Type::Int, Type::Int}}},
+    {BUILTIN_ARRAY_SET, {3, {Type::Int, Type::Int, Type::Int}}},
+    {BUILTIN_WRITE, {1, {Type::String}}}
 };
 
 const std::unordered_map<std::string, BuiltinInfo> &getBuiltinFunctions() {

--- a/compiler/builtins/builtins.h
+++ b/compiler/builtins/builtins.h
@@ -23,6 +23,11 @@ constexpr const char BUILTIN_PRINT[] = "willt’aña";
 constexpr const char BUILTIN_INPUT[] = "input";
 constexpr const char BUILTIN_LENGTH[] = "length";
 constexpr const char BUILTIN_RANDOM[] = "random";
+constexpr const char BUILTIN_WRITE[] = "write";
+constexpr const char BUILTIN_SLEEP[] = "sleep";
+constexpr const char BUILTIN_ARRAY_NEW[] = "array";
+constexpr const char BUILTIN_ARRAY_GET[] = "array_get";
+constexpr const char BUILTIN_ARRAY_SET[] = "array_set";
 
 const std::unordered_map<std::string, BuiltinInfo> &getBuiltinFunctions();
 std::string typeName(Type t);

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -604,6 +604,40 @@ void CodeGenImpl::emitExpr(const Expr *expr,
             out << "    mov " << reg1(this->windows) << ", rax\n";
             out << "    call aym_random\n";
             return;
+        } else if (c->getName() == BUILTIN_SLEEP) {
+            emitExpr(c->getArgs()[0].get(), locals);
+            out << "    mov " << reg1(this->windows) << ", rax\n";
+            out << "    call aym_sleep\n";
+            return;
+        } else if (c->getName() == BUILTIN_ARRAY_NEW) {
+            emitExpr(c->getArgs()[0].get(), locals);
+            out << "    mov " << reg1(this->windows) << ", rax\n";
+            out << "    call aym_array_new\n";
+            return;
+        } else if (c->getName() == BUILTIN_ARRAY_GET) {
+            emitExpr(c->getArgs()[1].get(), locals);
+            out << "    mov " << reg2(this->windows) << ", rax\n";
+            emitExpr(c->getArgs()[0].get(), locals);
+            out << "    mov " << reg1(this->windows) << ", rax\n";
+            out << "    call aym_array_get\n";
+            return;
+        } else if (c->getName() == BUILTIN_ARRAY_SET) {
+            std::vector<std::string> regs = paramRegs(this->windows);
+            emitExpr(c->getArgs()[2].get(), locals);
+            out << "    mov " << regs[2] << ", rax\n";
+            emitExpr(c->getArgs()[1].get(), locals);
+            out << "    mov " << regs[1] << ", rax\n";
+            emitExpr(c->getArgs()[0].get(), locals);
+            out << "    mov " << regs[0] << ", rax\n";
+            out << "    call aym_array_set\n";
+            return;
+        } else if (c->getName() == BUILTIN_WRITE) {
+            emitExpr(c->getArgs()[0].get(), locals);
+            out << "    mov " << reg2(this->windows) << ", rax\n";
+            out << "    lea " << reg1(this->windows) << ", [rel fmt_raw]\n";
+            out << "    xor eax,eax\n";
+            out << "    call printf\n";
+            return;
         }
         // user function call
         std::vector<std::string> regs = paramRegs(this->windows);
@@ -669,9 +703,14 @@ void CodeGenImpl::emit(const std::vector<std::unique_ptr<Node>> &nodes,
     out << "extern scanf\n";
     out << "extern strlen\n";
     out << "extern aym_random\n";
+    out << "extern aym_sleep\n";
+    out << "extern aym_array_new\n";
+    out << "extern aym_array_get\n";
+    out << "extern aym_array_set\n";
     out << "section .data\n";
     out << "fmt_int: db \"%ld\",10,0\n";
     out << "fmt_str: db \"%s\",10,0\n";
+    out << "fmt_raw: db \"%s\",0\n";
     out << "fmt_read_int: db \"%ld\",0\n";
     out << "fmt_read_str: db \"%255s\",0\n";
     out << "input_val: dq 0\n";

--- a/compiler/interpreter/interpreter.cpp
+++ b/compiler/interpreter/interpreter.cpp
@@ -3,6 +3,9 @@
 #include <iostream>
 #include <cstdlib>
 #include <ctime>
+#include <vector>
+#include <thread>
+#include <chrono>
 
 namespace aym {
 
@@ -41,6 +44,7 @@ Value Interpreter::eval(Expr *expr) {
 }
 
 Value Interpreter::callFunction(const std::string &name, const std::vector<Value>& args) {
+    static std::vector<std::vector<long>> arrays;
     auto it = functions.find(name);
     if (it != functions.end()) {
         pushScope();
@@ -87,6 +91,34 @@ Value Interpreter::callFunction(const std::string &name, const std::vector<Value
             return Value::Int(std::rand() % args[0].i);
         }
         return Value::Int(std::rand());
+    }
+    if (name == BUILTIN_WRITE) {
+        if (!args.empty() && args[0].type == Value::Type::String)
+            std::cout << args[0].s;
+        return Value::Void();
+    }
+    if (name == BUILTIN_SLEEP) {
+        if (!args.empty()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(args[0].i));
+        }
+        return Value::Void();
+    }
+    if (name == BUILTIN_ARRAY_NEW) {
+        long handle = arrays.size();
+        arrays.push_back(std::vector<long>(args.empty() ? 0 : args[0].i));
+        return Value::Int(handle);
+    }
+    if (name == BUILTIN_ARRAY_GET) {
+        if (args.size() >= 2 && args[0].i < arrays.size()) {
+            return Value::Int(arrays[args[0].i][args[1].i]);
+        }
+        return Value::Int(0);
+    }
+    if (name == BUILTIN_ARRAY_SET) {
+        if (args.size() >= 3 && args[0].i < arrays.size()) {
+            arrays[args[0].i][args[1].i] = args[2].i;
+        }
+        return Value::Void();
     }
     return Value::Void();
 }

--- a/docs/aymaraLang.md
+++ b/docs/aymaraLang.md
@@ -14,6 +14,9 @@ AymaraLang (`aym`) es un lenguaje de programación experimental con sintaxis ins
 - Lectura de consola con `input()`
 - Longitud de cadenas con `length()`
 - Números aleatorios con `random(max)`
+- Pausa de ejecución con `sleep(ms)`
+- Impresión sin salto de línea con `write(str)`
+- Arreglos dinámicos con `array(n)`, `array_get(arr, i)`, `array_set(arr, i, v)`
  
 ## Compilación
 Para compilar un archivo `.aym` se ejecuta:
@@ -32,7 +35,7 @@ El compilador produce un archivo NASM, lo ensambla y enlaza automáticamente.
 - `return` fuera de una función
 
 ## Palabras clave
-`willt’aña`, `si`, `sino`, `mientras`, `haceña`, `para`, `en`, `jalña`, `sarantaña`, `luräwi`, `kutiyana`, `tantachaña`, `jamusa`, `akhamawa`, `uka`, `jan uka`, `janiwa`, `jach’a`, `lliphiphi`, `chuymani`, `qillqa`, `input`, `length`, `random`
+`willt’aña`, `write`, `sleep`, `array`, `array_get`, `array_set`, `si`, `sino`, `mientras`, `haceña`, `para`, `en`, `jalña`, `sarantaña`, `luräwi`, `kutiyana`, `tantachaña`, `jamusa`, `akhamawa`, `uka`, `jan uka`, `janiwa`, `jach’a`, `lliphiphi`, `chuymani`, `qillqa`, `input`, `length`, `random`
 
 ### Valores booleanos
 En `aym` los literales lógicos utilizan vocabulario aimara. La palabra
@@ -92,6 +95,7 @@ Este fragmento puede encontrarse en `samples/range_for.aym`.
 | Aimara / Español | Significado |
 |------------------|------------|
 | `willt’aña`      | imprimir |
+| `write`          | imprimir sin salto |
 | `si`             | if |
 | `sino`           | else |
 | `mientras`       | while |

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -2,6 +2,12 @@
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
+#include <stdint.h>
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
 
 void leer_linea(char *buf, int size) {
     if (fgets(buf, size, stdin)) {
@@ -20,5 +26,31 @@ int aym_random(int max) {
     }
     if (max > 0) return rand() % max;
     return rand();
+}
+
+void aym_sleep(int ms) {
+    if (ms <= 0) return;
+#ifdef _WIN32
+    Sleep(ms);
+#else
+    usleep((useconds_t)ms * 1000);
+#endif
+}
+
+long aym_array_new(long size) {
+    if (size <= 0) return 0;
+    long *arr = calloc((size_t)size, sizeof(long));
+    return (long)arr;
+}
+
+long aym_array_get(long arr, long idx) {
+    long *a = (long*)arr;
+    return a[idx];
+}
+
+long aym_array_set(long arr, long idx, long val) {
+    long *a = (long*)arr;
+    a[idx] = val;
+    return val;
 }
 

--- a/samples/tetris.aym
+++ b/samples/tetris.aym
@@ -1,0 +1,86 @@
+jach’a ancho = 10;
+jach’a alto = 20;
+jach’a tablero = array(ancho * alto);
+
+luräwi indice(x, y) {
+    kutiyana(y * ancho + x);
+}
+
+luräwi obtener(x, y) {
+    kutiyana(array_get(tablero, indice(x, y)));
+}
+
+luräwi fijar(x, y, v) {
+    array_set(tablero, indice(x, y), v);
+}
+
+luräwi dibujar() {
+    jach’a y = 0;
+    mientras (y < alto) {
+        jach’a x = 0;
+        mientras (x < ancho) {
+            si (obtener(x, y)) {
+                write("#");
+            } sino {
+                write(".");
+            }
+            x = x + 1;
+        }
+        willt’aña("");
+        y = y + 1;
+    }
+}
+
+luräwi puede(x, y) {
+    jach’a i = 0;
+    mientras (i < 2) {
+        jach’a j = 0;
+        mientras (j < 2) {
+            jach’a nx = x + j;
+            jach’a ny = y + i;
+            si (nx >= ancho || ny >= alto) {
+                kutiyana(0);
+            }
+            si (obtener(nx, ny)) {
+                kutiyana(0);
+            }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    kutiyana(1);
+}
+
+luräwi poner(x, y, v) {
+    jach’a i = 0;
+    mientras (i < 2) {
+        jach’a j = 0;
+        mientras (j < 2) {
+            fijar(x + j, y + i, v);
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+}
+
+jach’a px = ancho / 2 - 1;
+jach’a py = 0;
+poner(px, py, 1);
+
+mientras (1) {
+    dibujar();
+    sleep(300);
+    si (puede(px, py + 1)) {
+        poner(px, py, 0);
+        py = py + 1;
+        poner(px, py, 1);
+    } sino {
+        py = 0;
+        px = random(ancho - 1);
+        si (!puede(px, py)) {
+            willt’aña("Game Over");
+            jalña;
+        }
+        poner(px, py, 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add new built-ins for arrays, non-newline output and sleeping
- implement runtime helpers for array access and delays
- provide a simple Tetris sample using the new features

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68bdf4c241c88327b736245d2d569b5a