### PR TITLE
Fix array handling in interpreter and runtime

### DIFF
--- a/compiler/interpreter/interpreter.cpp
+++ b/compiler/interpreter/interpreter.cpp
@@ -109,14 +109,14 @@ Value Interpreter::callFunction(const std::string &name, const std::vector<Value
         return Value::Int(handle);
     }
     if (name == BUILTIN_ARRAY_GET) {
-        if (args.size() >= 2 && args[0].i < arrays.size()) {
-            return Value::Int(arrays[args[0].i][args[1].i]);
+        if (args.size() >= 2 && args[0].i >= 0 && static_cast<size_t>(args[0].i) < arrays.size()) {
+            return Value::Int(arrays[static_cast<size_t>(args[0].i)][args[1].i]);
         }
         return Value::Int(0);
     }
     if (name == BUILTIN_ARRAY_SET) {
-        if (args.size() >= 3 && args[0].i < arrays.size()) {
-            arrays[args[0].i][args[1].i] = args[2].i;
+        if (args.size() >= 3 && args[0].i >= 0 && static_cast<size_t>(args[0].i) < arrays.size()) {
+            arrays[static_cast<size_t>(args[0].i)][args[1].i] = args[2].i;
         }
         return Value::Void();
     }

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -37,18 +37,18 @@ void aym_sleep(int ms) {
 #endif
 }
 
-long aym_array_new(long size) {
+intptr_t aym_array_new(long size) {
     if (size <= 0) return 0;
     long *arr = calloc((size_t)size, sizeof(long));
-    return (long)arr;
+    return (intptr_t)arr;
 }
 
-long aym_array_get(long arr, long idx) {
+long aym_array_get(intptr_t arr, long idx) {
     long *a = (long*)arr;
     return a[idx];
 }
 
-long aym_array_set(long arr, long idx, long val) {
+long aym_array_set(intptr_t arr, long idx, long val) {
     long *a = (long*)arr;
     a[idx] = val;
     return val;


### PR DESCRIPTION
## Summary
- avoid comparing signed array identifiers with unsigned size in interpreter
- use pointer-sized integer for runtime array handles to prevent pointer cast warnings

## Testing
- `make`
- `make test`
- `./bin/aymc samples/tetris.aym`


------
https://chatgpt.com/codex/tasks/task_e_68bdffb97ea08327996e2fe8ea68dd58