### PR TITLE
Fix array handling in interpreter and runtime

### DIFF
--- a/compiler/interpreter/interpreter.cpp
+++ b/compiler/interpreter/interpreter.cpp
@@ -109,14 +109,14 @@ Value Interpreter::callFunction(const std::string &name, const std::vector<Value
         return Value::Int(handle);
     }
     if (name == BUILTIN_ARRAY_GET) {
-        if (args.size() >= 2 && args[0].i < arrays.size()) {
-            return Value::Int(arrays[args[0].i][args[1].i]);
+        if (args.size() >= 2 && args[0].i >= 0 && static_cast<size_t>(args[0].i) < arrays.size()) {
+            return Value::Int(arrays[static_cast<size_t>(args[0].i)][args[1].i]);
         }
         return Value::Int(0);
     }
     if (name == BUILTIN_ARRAY_SET) {
-        if (args.size() >= 3 && args[0].i < arrays.size()) {
-            arrays[args[0].i][args[1].i] = args[2].i;
+        if (args.size() >= 3 && args[0].i >= 0 && static_cast<size_t>(args[0].i) < arrays.size()) {
+            arrays[static_cast<size_t>(args[0].i)][args[1].i] = args[2].i;
         }
         return Value::Void();
     }

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -37,18 +37,18 @@ void aym_sleep(int ms) {
 #endif
 }
 
-long aym_array_new(long size) {
+intptr_t aym_array_new(long size) {
     if (size <= 0) return 0;
     long *arr = calloc((size_t)size, sizeof(long));
-    return (long)arr;
+    return (intptr_t)arr;
 }
 
-long aym_array_get(long arr, long idx) {
+long aym_array_get(intptr_t arr, long idx) {
     long *a = (long*)arr;
     return a[idx];
 }
 
-long aym_array_set(long arr, long idx, long val) {
+long aym_array_set(intptr_t arr, long idx, long val) {
     long *a = (long*)arr;
     a[idx] = val;
     return val;

--- a/samples/tetris.aym
+++ b/samples/tetris.aym
@@ -15,6 +15,9 @@ luräwi fijar(x, y, v) {
 }
 
 luräwi dibujar() {
+    // limpiar pantalla y posicionar cursor
+    write("\x1b[H\x1b[2J");
+
     jach’a y = 0;
     mientras (y < alto) {
         jach’a x = 0;
@@ -69,7 +72,27 @@ poner(px, py, 1);
 
 mientras (1) {
     dibujar();
-    sleep(300);
+
+    // leer entrada del usuario para mover la pieza
+    qillqa c = input();
+    si (c == "a" && puede(px - 1, py)) {
+        poner(px, py, 0);
+        px = px - 1;
+        poner(px, py, 1);
+    } sino si (c == "d" && puede(px + 1, py)) {
+        poner(px, py, 0);
+        px = px + 1;
+        poner(px, py, 1);
+    } sino si (c == "s" && puede(px, py + 1)) {
+        poner(px, py, 0);
+        py = py + 1;
+        poner(px, py, 1);
+    } sino si (c == "q") {
+        willt’aña("Game Over");
+        jalña;
+    }
+
+    // gravedad: la pieza cae automáticamente
     si (puede(px, py + 1)) {
         poner(px, py, 0);
         py = py + 1;


### PR DESCRIPTION
## Summary
- avoid comparing signed array identifiers with unsigned size in interpreter
- use pointer-sized integer for runtime array handles to prevent pointer cast warnings
- add interactive controls to the Tetris sample to allow moving pieces and quitting the game

## Testing
- `make`
- `make test`
- `./bin/aymc samples/tetris.aym`
- `printf "q\n" | ./bin/tetris`


------
https://chatgpt.com/codex/tasks/task_e_68bdffb97ea08327996e2fe8ea68dd58