### PR TITLE
Handle array allocation failures

### DIFF
--- a/compiler/interpreter/interpreter.cpp
+++ b/compiler/interpreter/interpreter.cpp
@@ -105,28 +105,51 @@ Value Interpreter::callFunction(const std::string &name, const std::vector<Value
         return Value::Void();
     }
     if (name == BUILTIN_ARRAY_NEW) {
-        long handle = arrays.size();
-        arrays.push_back(std::vector<long>(args.empty() ? 0 : args[0].i));
-        arraysValid.push_back(true);
+        long handle = 0;
+        try {
+            arrays.emplace_back(args.empty() ? 0 : args[0].i);
+            arraysValid.push_back(true);
+            handle = arrays.size();
+        } catch (const std::bad_alloc &) {
+            handle = 0;
+        }
         return Value::Int(handle);
     }
     if (name == BUILTIN_ARRAY_GET) {
-        if (args.size() >= 2 && args[0].i >= 0 && static_cast<size_t>(args[0].i) < arrays.size() && arraysValid[static_cast<size_t>(args[0].i)]) {
-            return Value::Int(arrays[static_cast<size_t>(args[0].i)][args[1].i]);
+        if (args.size() >= 2) {
+            long handle = args[0].i;
+            if (handle > 0) {
+                size_t idx = static_cast<size_t>(handle - 1);
+                if (idx < arrays.size() && arraysValid[idx]) {
+                    return Value::Int(arrays[idx][args[1].i]);
+                }
+            }
         }
         return Value::Int(0);
     }
     if (name == BUILTIN_ARRAY_SET) {
-        if (args.size() >= 3 && args[0].i >= 0 && static_cast<size_t>(args[0].i) < arrays.size() && arraysValid[static_cast<size_t>(args[0].i)]) {
-            arrays[static_cast<size_t>(args[0].i)][args[1].i] = args[2].i;
+        if (args.size() >= 3) {
+            long handle = args[0].i;
+            if (handle > 0) {
+                size_t idx = static_cast<size_t>(handle - 1);
+                if (idx < arrays.size() && arraysValid[idx]) {
+                    arrays[idx][args[1].i] = args[2].i;
+                }
+            }
         }
         return Value::Void();
     }
     if (name == BUILTIN_ARRAY_FREE) {
-        if (args.size() >= 1 && args[0].i >= 0 && static_cast<size_t>(args[0].i) < arrays.size() && arraysValid[static_cast<size_t>(args[0].i)]) {
-            arrays[static_cast<size_t>(args[0].i)].clear();
-            arrays[static_cast<size_t>(args[0].i)].shrink_to_fit();
-            arraysValid[static_cast<size_t>(args[0].i)] = false;
+        if (args.size() >= 1) {
+            long handle = args[0].i;
+            if (handle > 0) {
+                size_t idx = static_cast<size_t>(handle - 1);
+                if (idx < arrays.size() && arraysValid[idx]) {
+                    arrays[idx].clear();
+                    arrays[idx].shrink_to_fit();
+                    arraysValid[idx] = false;
+                }
+            }
         }
         return Value::Void();
     }

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -41,7 +41,10 @@ intptr_t aym_array_new(long size) {
     if (size <= 0) return 0;
     // allocate extra slot to store array length
     long *arr = calloc((size_t)size + 1, sizeof(long));
-    if (!arr) return 0;
+    if (!arr) {
+        fprintf(stderr, "aym_array_new: allocation failed\n");
+        return 0;
+    }
     arr[0] = size;            // store length at the first position
     return (intptr_t)(arr + 1); // return pointer to data region
 }


### PR DESCRIPTION
## Summary
- guard against failed array allocation in runtime and report errors
- validate array handles in interpreter builtins and use 1-based indices

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68be25512b4c8327acf133d5c535cf85