### PR TITLE
Support float and boolean printing in interpreter

### DIFF
--- a/compiler/interpreter/interpreter.cpp
+++ b/compiler/interpreter/interpreter.cpp
@@ -70,6 +70,10 @@ Value Interpreter::callFunction(const std::string &name, const std::vector<Value
                 std::cout << args[0].s << std::endl;
             else if (args[0].type == Value::Type::Int)
                 std::cout << args[0].i << std::endl;
+            else if (args[0].type == Value::Type::Float)
+                std::cout << args[0].f << std::endl;
+            else if (args[0].type == Value::Type::Bool)
+                std::cout << (args[0].b ? "cheka" : "janiwa") << std::endl;
         }
         return Value::Void();
     }

--- a/compiler/interpreter/interpreter.h
+++ b/compiler/interpreter/interpreter.h
@@ -10,12 +10,14 @@
 namespace aym {
 
 struct Value {
-    enum class Type { Int, Bool, String, Void } type = Type::Void;
+    enum class Type { Int, Float, Bool, String, Void } type = Type::Void;
     long i = 0;
+    double f = 0.0;
     bool b = false;
     std::string s;
 
     static Value Int(long v) { Value val; val.type = Type::Int; val.i = v; return val; }
+    static Value Float(double v) { Value val; val.type = Type::Float; val.f = v; return val; }
     static Value Bool(bool v) { Value val; val.type = Type::Bool; val.b = v; return val; }
     static Value String(std::string v) { Value val; val.type = Type::String; val.s = std::move(v); return val; }
     static Value Void() { return Value(); }

--- a/tests/unittests/test_compiler.cpp
+++ b/tests/unittests/test_compiler.cpp
@@ -3,6 +3,12 @@
 #include "compiler/parser/parser.h"
 #include "compiler/codegen/codegen.h"
 #include "compiler/ast/ast.h"
+#define private public
+#define protected public
+#include "compiler/interpreter/interpreter.h"
+#undef private
+#undef protected
+#include "compiler/builtins/builtins.h"
 #include <fstream>
 #include <cstdio>
 
@@ -84,6 +90,23 @@ TEST(CodeGenTest, GeneratesAssembly) {
     std::remove("build/test_output.o");
     std::remove("bin/test_output");
 #endif
+}
+
+TEST(InterpreterTest, BuiltinPrintFloat) {
+    Interpreter interp;
+    testing::internal::CaptureStdout();
+    interp.callFunction(BUILTIN_PRINT, {Value::Float(3.14)});
+    std::string output = testing::internal::GetCapturedStdout();
+    EXPECT_EQ(output, std::string("3.14\n"));
+}
+
+TEST(InterpreterTest, BuiltinPrintBool) {
+    Interpreter interp;
+    testing::internal::CaptureStdout();
+    interp.callFunction(BUILTIN_PRINT, {Value::Bool(true)});
+    interp.callFunction(BUILTIN_PRINT, {Value::Bool(false)});
+    std::string output = testing::internal::GetCapturedStdout();
+    EXPECT_EQ(output, std::string("cheka\njaniwa\n"));
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## Summary
- handle `lliphiphi` and `chuymani` values in the interpreter's built-in print function
- expand the Value type with Float support
- add unit tests verifying float and boolean printing

## Testing
- `g++ -std=c++17 tests/unittests/test_compiler.cpp $(find compiler -name '*.cpp' ! -name 'main.cpp') -I. -pthread -lgtest -lgtest_main -o tests/unittests/test_compiler`
- `./tests/unittests/test_compiler`


------
https://chatgpt.com/codex/tasks/task_e_68be2d2ed2b88327babb135f2ea29b7e