### PR TITLE
Detect missing identifiers during interpretation

### DIFF
--- a/compiler/interpreter/interpreter.cpp
+++ b/compiler/interpreter/interpreter.cpp
@@ -26,7 +26,8 @@ Value Interpreter::lookup(const std::string &name) {
         auto f = it->find(name);
         if (f != it->end()) return f->second;
     }
-    return Value::Int(0);
+    std::cerr << "Error: undefined identifier '" << name << "'" << std::endl;
+    throw std::runtime_error("undefined identifier: " + name);
 }
 
 void Interpreter::assign(const std::string &name, const Value &val) {

--- a/tests/unittests/test_compiler.cpp
+++ b/tests/unittests/test_compiler.cpp
@@ -11,6 +11,7 @@
 #include "compiler/builtins/builtins.h"
 #include <fstream>
 #include <cstdio>
+#include <stdexcept>
 
 using namespace aym;
 
@@ -107,6 +108,11 @@ TEST(InterpreterTest, BuiltinPrintBool) {
     interp.callFunction(BUILTIN_PRINT, {Value::Bool(false)});
     std::string output = testing::internal::GetCapturedStdout();
     EXPECT_EQ(output, std::string("cheka\njaniwa\n"));
+}
+
+TEST(InterpreterTest, LookupUndefinedVariableThrows) {
+    Interpreter interp;
+    EXPECT_THROW(interp.lookup("missing"), std::runtime_error);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## Summary
- Throw a runtime error when the interpreter fails to find a variable
- Add a unit test for missing identifier lookup

## Testing
- `make test`
- `./tests/unittests/test_compiler`


------
https://chatgpt.com/codex/tasks/task_e_68be340a06a4832797c7a1ea65634c15