### PR TITLE
Handle escaped characters in string literals

### DIFF
--- a/compiler/lexer/lexer.cpp
+++ b/compiler/lexer/lexer.cpp
@@ -124,10 +124,25 @@ std::vector<Token> Lexer::tokenize() {
         if (c == '"') {
             get();
             std::string str;
-            while (pos < src.size() && peek() != '"') {
-                str += get();
+            while (pos < src.size()) {
+                char ch = get();
+                if (ch == '"') break;
+                if (ch == '\\') {
+                    if (pos >= src.size()) break;
+                    char esc = get();
+                    switch (esc) {
+                        case 'n': str += '\n'; break;
+                        case 't': str += '\t'; break;
+                        case 'r': str += '\r'; break;
+                        case '\\': str += '\\'; break;
+                        case '"': str += '"'; break;
+                        case '0': str += '\0'; break;
+                        default: str += esc; break;
+                    }
+                } else {
+                    str += ch;
+                }
             }
-            get(); // closing quote
             tokens.push_back({TokenType::String, str, startLine, startColumn});
             continue;
         }

--- a/tests/unittests/test_compiler.cpp
+++ b/tests/unittests/test_compiler.cpp
@@ -28,6 +28,15 @@ TEST(LexerTest, SimpleTokenize) {
     EXPECT_EQ(tokens[5].type, TokenType::EndOfFile);
 }
 
+TEST(LexerTest, EscapedString) {
+    Lexer lexer(R"("line1\nline2\t\"quoted\"\\")");
+    auto tokens = lexer.tokenize();
+    ASSERT_EQ(tokens.size(), 2u);
+    EXPECT_EQ(tokens[0].type, TokenType::String);
+    EXPECT_EQ(tokens[0].text, std::string("line1\nline2\t\"quoted\"\\"));
+    EXPECT_EQ(tokens[1].type, TokenType::EndOfFile);
+}
+
 TEST(ParserTest, ParsePrintStmt) {
     Lexer lexer("willt’aña(1);");
     auto tokens = lexer.tokenize();


### PR DESCRIPTION
## Summary
- Extend lexer string handling to decode escape sequences like `\n`, `\t`, `\"` and `\\`.
- Add unit test covering escaped string literals.

## Testing
- `make test`
- `g++ -std=c++17 tests/unittests/test_compiler.cpp $(find compiler -name '*.cpp' ! -name 'main.cpp') -I. -pthread -lgtest -o tests/unittests/test_compiler_bin`
- `./tests/unittests/test_compiler_bin`

------
https://chatgpt.com/codex/tasks/task_e_68be37e729f8832786d18dc47f2c3986