### PR TITLE
Handle unterminated lexer constructs

### DIFF
--- a/tests/unittests/test_compiler.cpp
+++ b/tests/unittests/test_compiler.cpp
@@ -37,6 +37,23 @@ TEST(LexerTest, EscapedString) {
     EXPECT_EQ(tokens[1].type, TokenType::EndOfFile);
 }
 
+TEST(LexerTest, UnterminatedString) {
+    Lexer lexer("\"missing end");
+    try {
+        lexer.tokenize();
+        FAIL() << "Expected std::runtime_error";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("line 1"), std::string::npos);
+        EXPECT_NE(msg.find("column 1"), std::string::npos);
+    }
+}
+
+TEST(LexerTest, UnterminatedBlockComment) {
+    Lexer lexer("/* comment");
+    EXPECT_THROW(lexer.tokenize(), std::runtime_error);
+}
+
 TEST(ParserTest, ParsePrintStmt) {
     Lexer lexer("willt’aña(1);");
     auto tokens = lexer.tokenize();


### PR DESCRIPTION
## Summary
- Detect end-of-file when scanning strings or block comments and throw a descriptive error with start position
- Add unit tests for unterminated strings and block comments

## Testing
- `make test`
- `g++ -std=c++17 -I. tests/unittests/test_compiler.cpp $(find compiler -name '*.cpp' ! -name 'main.cpp') -lgtest -pthread -o tests/unittests/test_compiler`
- `tests/unittests/test_compiler`


------
https://chatgpt.com/codex/tasks/task_e_68c81e0628308327a1d2c1f38f91d81c