### PR TITLE
Add array_length builtin

### DIFF
--- a/compiler/builtins/builtins.cpp
+++ b/compiler/builtins/builtins.cpp
@@ -12,6 +12,7 @@ static const std::unordered_map<std::string, BuiltinInfo> builtins = {
     {BUILTIN_ARRAY_GET, {2, {Type::Int, Type::Int}}},
     {BUILTIN_ARRAY_SET, {3, {Type::Int, Type::Int, Type::Int}}},
     {BUILTIN_ARRAY_FREE, {1, {Type::Int}}},
+    {BUILTIN_ARRAY_LENGTH, {1, {Type::Int}}},
     {BUILTIN_WRITE, {1, {Type::String}}}
 };
 

--- a/compiler/builtins/builtins.h
+++ b/compiler/builtins/builtins.h
@@ -29,6 +29,7 @@ constexpr const char BUILTIN_ARRAY_NEW[] = "array";
 constexpr const char BUILTIN_ARRAY_GET[] = "array_get";
 constexpr const char BUILTIN_ARRAY_SET[] = "array_set";
 constexpr const char BUILTIN_ARRAY_FREE[] = "array_free";
+constexpr const char BUILTIN_ARRAY_LENGTH[] = "array_length";
 
 const std::unordered_map<std::string, BuiltinInfo> &getBuiltinFunctions();
 std::string typeName(Type t);

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -636,6 +636,11 @@ void CodeGenImpl::emitExpr(const Expr *expr,
             out << "    mov " << reg1(this->windows) << ", rax\n";
             out << "    call aym_array_free\n";
             return;
+        } else if (c->getName() == BUILTIN_ARRAY_LENGTH) {
+            emitExpr(c->getArgs()[0].get(), locals);
+            out << "    mov " << reg1(this->windows) << ", rax\n";
+            out << "    call aym_array_length\n";
+            return;
         } else if (c->getName() == BUILTIN_WRITE) {
             emitExpr(c->getArgs()[0].get(), locals);
             out << "    mov " << reg2(this->windows) << ", rax\n";
@@ -713,6 +718,7 @@ void CodeGenImpl::emit(const std::vector<std::unique_ptr<Node>> &nodes,
     out << "extern aym_array_get\n";
     out << "extern aym_array_set\n";
     out << "extern aym_array_free\n";
+    out << "extern aym_array_length\n";
     out << "section .data\n";
     out << "fmt_int: db \"%ld\",10,0\n";
     out << "fmt_str: db \"%s\",10,0\n";

--- a/compiler/interpreter/interpreter.cpp
+++ b/compiler/interpreter/interpreter.cpp
@@ -170,6 +170,19 @@ Value Interpreter::callFunction(const std::string &name, const std::vector<Value
         }
         return Value::Void();
     }
+    if (name == BUILTIN_ARRAY_LENGTH) {
+        if (args.size() >= 1) {
+            long handle = args[0].i;
+            if (handle > 0) {
+                size_t idx = static_cast<size_t>(handle - 1);
+                if (idx < this->arrays.size() && this->arraysValid[idx]) {
+                    auto &arr = this->arrays[idx];
+                    return Value::Int(arr.size());
+                }
+            }
+        }
+        return Value::Int(0);
+    }
     return Value::Void();
 }
 

--- a/docs/aymaraLang.md
+++ b/docs/aymaraLang.md
@@ -16,7 +16,7 @@ AymaraLang (`aym`) es un lenguaje de programación experimental con sintaxis ins
 - Números aleatorios con `random(max)`
 - Pausa de ejecución con `sleep(ms)`
 - Impresión sin salto de línea con `write(str)`
-- Arreglos dinámicos con `array(n)`, `array_get(arr, i)`, `array_set(arr, i, v)`, `array_free(arr)`
+- Arreglos dinámicos con `array(n)`, `array_get(arr, i)`, `array_set(arr, i, v)`, `array_free(arr)`, `array_length(arr)`
  
 ## Compilación
 Para compilar un archivo `.aym` se ejecuta:
@@ -35,7 +35,7 @@ El compilador produce un archivo NASM, lo ensambla y enlaza automáticamente.
 - `return` fuera de una función
 
 ## Palabras clave
-`willt’aña`, `write`, `sleep`, `array`, `array_get`, `array_set`, `array_free`, `si`, `sino`, `mientras`, `haceña`, `para`, `en`, `jalña`, `sarantaña`, `luräwi`, `kutiyana`, `tantachaña`, `jamusa`, `akhamawa`, `uka`, `jan uka`, `janiwa`, `jach’a`, `lliphiphi`, `chuymani`, `qillqa`, `input`, `length`, `random`
+`willt’aña`, `write`, `sleep`, `array`, `array_get`, `array_set`, `array_free`, `array_length`, `si`, `sino`, `mientras`, `haceña`, `para`, `en`, `jalña`, `sarantaña`, `luräwi`, `kutiyana`, `tantachaña`, `jamusa`, `akhamawa`, `uka`, `jan uka`, `janiwa`, `jach’a`, `lliphiphi`, `chuymani`, `qillqa`, `input`, `length`, `random`
 
 ### Valores booleanos
 En `aym` los literales lógicos utilizan vocabulario aimara. La palabra

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -74,3 +74,10 @@ void aym_array_free(intptr_t arr) {
     free(base);
 }
 
+long aym_array_length(intptr_t arr) {
+    if (!arr) return 0;
+    long *a = (long*)arr;
+    long len = *(a - 1);
+    return len;
+}
+

--- a/samples/array_length.aym
+++ b/samples/array_length.aym
@@ -1,0 +1,6 @@
+jach’a arr = array(3);
+array_set(arr, 0, 10);
+array_set(arr, 1, 20);
+array_set(arr, 2, 30);
+willt’aña(array_length(arr));
+array_free(arr);

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -30,4 +30,7 @@ make >/dev/null
 ./bin/aymc samples/random.aym >/dev/null
 ./bin/random >/dev/null
 
+./bin/aymc samples/array_length.aym >/dev/null
+./bin/array_length | grep -q -- 3
+
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -25,6 +25,7 @@ run advanced_ops 8
 run string Kamisaraki
 run range_for 3
 run negativos -7
+run array_length 3
 ./bin/aymc samples/random.aym >/dev/null
 ./bin/random >/dev/null
 

--- a/tests/unittests/test_compiler.cpp
+++ b/tests/unittests/test_compiler.cpp
@@ -136,6 +136,14 @@ TEST(InterpreterTest, BuiltinPrintBool) {
     EXPECT_EQ(output, std::string("cheka\njaniwa\n"));
 }
 
+TEST(InterpreterTest, BuiltinArrayLength) {
+    Interpreter interp;
+    auto handle = interp.callFunction(BUILTIN_ARRAY_NEW, {Value::Int(5)});
+    auto len = interp.callFunction(BUILTIN_ARRAY_LENGTH, {handle});
+    EXPECT_EQ(len.i, 5);
+    interp.callFunction(BUILTIN_ARRAY_FREE, {handle});
+}
+
 TEST(InterpreterTest, LookupUndefinedVariableThrows) {
     Interpreter interp;
     EXPECT_THROW(interp.lookup("missing"), std::runtime_error);


### PR DESCRIPTION
## Summary
- introduce `array_length` builtin identifier
- support `array_length` in interpreter, code generation, and runtime
- document builtin and add tests and sample demonstrating usage

## Testing
- `make test`
- `g++ -std=c++17 tests/unittests/test_compiler.cpp build/lexer/lexer.o build/parser/parser.o build/ast/ast.o build/codegen/codegen.o build/utils/utils.o build/utils/error.o build/semantic/semantic.o build/builtins/builtins.o build/interpreter/interpreter.o -I. -o tests/unittests/test_compiler -lgtest -lgtest_main -lpthread`
- `./tests/unittests/test_compiler`

------
https://chatgpt.com/codex/tasks/task_e_68c81fa95fc4832780248ca497041e08