### PR TITLE
Add source locations to AST and runtime errors

### DIFF
--- a/compiler/ast/ast.h
+++ b/compiler/ast/ast.h
@@ -55,8 +55,18 @@ public:
 
 class Node {
 public:
+    Node() = default;
+    Node(size_t line, size_t column) : line(line), column(column) {}
     virtual ~Node() = default;
+
+    size_t getLine() const { return line; }
+    size_t getColumn() const { return column; }
+    void setLocation(size_t l, size_t c) { line = l; column = c; }
+
     virtual void accept(ASTVisitor &) = 0;
+private:
+    size_t line = 0;
+    size_t column = 0;
 };
 
 class Expr : public Node {

--- a/compiler/interpreter/interpreter.h
+++ b/compiler/interpreter/interpreter.h
@@ -65,12 +65,12 @@ private:
 
     void pushScope();
     void popScope();
-    Value lookup(const std::string &name);
+    Value lookup(const std::string &name, size_t line, size_t column);
     void assign(const std::string &name, const Value &val);
     void declare(const std::string &name, const Value &val);
 
     Value eval(Expr* expr);
-    Value callFunction(const std::string &name, const std::vector<Value>& args);
+    Value callFunction(const std::string &name, const std::vector<Value>& args, size_t line, size_t column);
 };
 
 } // namespace aym

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -38,91 +38,129 @@ void Parser::parseStatements(std::vector<std::unique_ptr<Stmt>> &nodes, bool sto
 std::unique_ptr<Stmt> Parser::parseSingleStatement() {
     if (match(TokenType::KeywordInt) || match(TokenType::KeywordFloat) ||
         match(TokenType::KeywordBool) || match(TokenType::KeywordString)) {
-        std::string type = tokens[pos-1].text;
+        Token typeTok = tokens[pos-1];
+        std::string type = typeTok.text;
         std::string name;
-        if (peek().type == TokenType::Identifier) name = get().text;
+        if (peek().type == TokenType::Identifier) {
+            name = get().text;
+        }
         std::unique_ptr<Expr> init;
         if (match(TokenType::Equal)) init = parseExpression();
         match(TokenType::Semicolon);
-        return std::make_unique<VarDeclStmt>(type, name, std::move(init));
+        auto node = std::make_unique<VarDeclStmt>(type, name, std::move(init));
+        node->setLocation(typeTok.line, typeTok.column);
+        return node;
     }
 
     if (match(TokenType::KeywordReturn)) {
+        Token tok = tokens[pos-1];
         std::unique_ptr<Expr> val;
         if (peek().type != TokenType::Semicolon) val = parseExpression();
         match(TokenType::Semicolon);
-        return std::make_unique<ReturnStmt>(std::move(val));
+        auto node = std::make_unique<ReturnStmt>(std::move(val));
+        node->setLocation(tok.line, tok.column);
+        return node;
     }
 
     if (match(TokenType::KeywordBreak)) {
+        Token tok = tokens[pos-1];
         match(TokenType::Semicolon);
-        return std::make_unique<BreakStmt>();
+        auto node = std::make_unique<BreakStmt>();
+        node->setLocation(tok.line, tok.column);
+        return node;
     }
 
     if (match(TokenType::KeywordContinue)) {
+        Token tok = tokens[pos-1];
         match(TokenType::Semicolon);
-        return std::make_unique<ContinueStmt>();
+        auto node = std::make_unique<ContinueStmt>();
+        node->setLocation(tok.line, tok.column);
+        return node;
     }
 
     if (match(TokenType::KeywordPrint)) {
+        Token tok = tokens[pos-1];
         match(TokenType::LParen);
         auto expr = parseExpression();
         match(TokenType::RParen);
         match(TokenType::Semicolon);
-        return std::make_unique<PrintStmt>(std::move(expr));
+        auto node = std::make_unique<PrintStmt>(std::move(expr));
+        node->setLocation(tok.line, tok.column);
+        return node;
     }
 
     if (match(TokenType::KeywordIf)) {
+        Token ifTok = tokens[pos-1];
         match(TokenType::LParen);
         auto cond = parseExpression();
         match(TokenType::RParen);
         match(TokenType::LBrace);
+        Token thenTok = tokens[pos-1];
         auto thenBlock = std::make_unique<BlockStmt>();
+        thenBlock->setLocation(thenTok.line, thenTok.column);
         parseStatements(thenBlock->statements, true);
         std::unique_ptr<BlockStmt> elseBlock;
         if (match(TokenType::KeywordElse)) {
+            Token elseTok = tokens[pos-1];
             if (match(TokenType::KeywordIf)) {
                 // else if -> treat as block containing nested if
                 --pos; // unread 'if' so parseSingleStatement sees it
                 auto nested = parseSingleStatement();
                 elseBlock = std::make_unique<BlockStmt>();
+                elseBlock->setLocation(elseTok.line, elseTok.column);
                 elseBlock->statements.push_back(std::move(nested));
             } else {
                 match(TokenType::LBrace);
+                Token elseBrace = tokens[pos-1];
                 elseBlock = std::make_unique<BlockStmt>();
+                elseBlock->setLocation(elseBrace.line, elseBrace.column);
                 parseStatements(elseBlock->statements, true);
             }
         }
-        return std::make_unique<IfStmt>(std::move(cond), std::move(thenBlock), std::move(elseBlock));
+        auto node = std::make_unique<IfStmt>(std::move(cond), std::move(thenBlock), std::move(elseBlock));
+        node->setLocation(ifTok.line, ifTok.column);
+        return node;
     }
 
 
     if (match(TokenType::KeywordWhile)) {
+        Token tok = tokens[pos-1];
         match(TokenType::LParen);
         auto cond = parseExpression();
         match(TokenType::RParen);
         match(TokenType::LBrace);
+        Token braceTok = tokens[pos-1];
         auto block = std::make_unique<BlockStmt>();
+        block->setLocation(braceTok.line, braceTok.column);
         parseStatements(block->statements, true);
-        return std::make_unique<WhileStmt>(std::move(cond), std::move(block));
+        auto node = std::make_unique<WhileStmt>(std::move(cond), std::move(block));
+        node->setLocation(tok.line, tok.column);
+        return node;
     }
 
     if (match(TokenType::KeywordDo)) {
+        Token doTok = tokens[pos-1];
         match(TokenType::LBrace);
+        Token braceTok = tokens[pos-1];
         auto body = std::make_unique<BlockStmt>();
+        body->setLocation(braceTok.line, braceTok.column);
         parseStatements(body->statements, true);
         match(TokenType::KeywordWhile);
         match(TokenType::LParen);
         auto cond = parseExpression();
         match(TokenType::RParen);
         match(TokenType::Semicolon);
-        return std::make_unique<DoWhileStmt>(std::move(body), std::move(cond));
+        auto node = std::make_unique<DoWhileStmt>(std::move(body), std::move(cond));
+        node->setLocation(doTok.line, doTok.column);
+        return node;
     }
 
     if (match(TokenType::KeywordFor)) {
+        Token forTok = tokens[pos-1];
         if (peek().type == TokenType::Identifier &&
             tokens[pos+1].type == TokenType::KeywordIn) {
             std::string name = get().text; // variable
+            Token nameTok = tokens[pos-1];
             match(TokenType::KeywordIn);
             if (peek().type == TokenType::Identifier && peek().text == "range") {
                 get();
@@ -132,13 +170,21 @@ std::unique_ptr<Stmt> Parser::parseSingleStatement() {
                 auto end = parseExpression();
                 match(TokenType::RParen);
                 match(TokenType::LBrace);
+                Token braceTok = tokens[pos-1];
                 auto body = std::make_unique<BlockStmt>();
+                body->setLocation(braceTok.line, braceTok.column);
                 parseStatements(body->statements, true);
                 auto init = std::make_unique<VarDeclStmt>("jach’a", name, std::move(start));
+                init->setLocation(nameTok.line, nameTok.column);
                 auto cond = std::make_unique<BinaryExpr>('<', std::make_unique<VariableExpr>(name), std::move(end));
+                cond->setLocation(nameTok.line, nameTok.column);
                 auto postExpr = std::make_unique<BinaryExpr>('+', std::make_unique<VariableExpr>(name), std::make_unique<NumberExpr>(1));
+                postExpr->setLocation(nameTok.line, nameTok.column);
                 auto post = std::make_unique<AssignStmt>(name, std::move(postExpr));
-                return std::make_unique<ForStmt>(std::move(init), std::move(cond), std::move(post), std::move(body));
+                post->setLocation(nameTok.line, nameTok.column);
+                auto node = std::make_unique<ForStmt>(std::move(init), std::move(cond), std::move(post), std::move(body));
+                node->setLocation(forTok.line, forTok.column);
+                return node;
             }
         }
 
@@ -149,12 +195,17 @@ std::unique_ptr<Stmt> Parser::parseSingleStatement() {
         auto post = parseSingleStatement();
         match(TokenType::RParen);
         match(TokenType::LBrace);
+        Token braceTok = tokens[pos-1];
         auto body = std::make_unique<BlockStmt>();
+        body->setLocation(braceTok.line, braceTok.column);
         parseStatements(body->statements, true);
-        return std::make_unique<ForStmt>(std::move(init), std::move(cond), std::move(post), std::move(body));
+        auto node = std::make_unique<ForStmt>(std::move(init), std::move(cond), std::move(post), std::move(body));
+        node->setLocation(forTok.line, forTok.column);
+        return node;
     }
 
     if (match(TokenType::KeywordSwitch)) {
+        Token switchTok = tokens[pos-1];
         match(TokenType::LParen);
         auto val = parseExpression();
         match(TokenType::RParen);
@@ -163,9 +214,11 @@ std::unique_ptr<Stmt> Parser::parseSingleStatement() {
         std::unique_ptr<BlockStmt> defCase;
         while (peek().type != TokenType::RBrace && peek().type != TokenType::EndOfFile) {
             if (match(TokenType::KeywordCase)) {
+                Token caseTok = tokens[pos-1];
                 auto cval = parseExpression();
                 match(TokenType::Colon);
                 auto blk = std::make_unique<BlockStmt>();
+                blk->setLocation(caseTok.line, caseTok.column);
                 while (peek().type != TokenType::KeywordCase &&
                        peek().type != TokenType::KeywordDefault &&
                        peek().type != TokenType::RBrace &&
@@ -174,8 +227,10 @@ std::unique_ptr<Stmt> Parser::parseSingleStatement() {
                 }
                 cases.emplace_back(std::move(cval), std::move(blk));
             } else if (match(TokenType::KeywordDefault)) {
+                Token defTok = tokens[pos-1];
                 match(TokenType::Colon);
                 defCase = std::make_unique<BlockStmt>();
+                defCase->setLocation(defTok.line, defTok.column);
                 while (peek().type != TokenType::RBrace &&
                        peek().type != TokenType::EndOfFile) {
                     defCase->statements.push_back(parseSingleStatement());
@@ -185,10 +240,13 @@ std::unique_ptr<Stmt> Parser::parseSingleStatement() {
             }
         }
         match(TokenType::RBrace);
-        return std::make_unique<SwitchStmt>(std::move(val), std::move(cases), std::move(defCase));
+        auto node = std::make_unique<SwitchStmt>(std::move(val), std::move(cases), std::move(defCase));
+        node->setLocation(switchTok.line, switchTok.column);
+        return node;
     }
 
     if (match(TokenType::KeywordFunc)) {
+        Token funcTok = tokens[pos-1];
         std::string name = "";
         if (peek().type == TokenType::Identifier) name = get().text;
         match(TokenType::LParen);
@@ -199,17 +257,24 @@ std::unique_ptr<Stmt> Parser::parseSingleStatement() {
         }
         match(TokenType::RParen);
         match(TokenType::LBrace);
+        Token bodyTok = tokens[pos-1];
         auto body = std::make_unique<BlockStmt>();
+        body->setLocation(bodyTok.line, bodyTok.column);
         parseStatements(body->statements, true);
-        return std::make_unique<FunctionStmt>(name, std::move(params), std::move(body));
+        auto node = std::make_unique<FunctionStmt>(name, std::move(params), std::move(body));
+        node->setLocation(funcTok.line, funcTok.column);
+        return node;
     }
 
     if (peek().type == TokenType::Identifier) {
         std::string name = get().text;
+        Token nameTok = tokens[pos-1];
         if (match(TokenType::Equal)) {
             auto value = parseExpression();
             match(TokenType::Semicolon);
-            return std::make_unique<AssignStmt>(name, std::move(value));
+            auto node = std::make_unique<AssignStmt>(name, std::move(value));
+            node->setLocation(nameTok.line, nameTok.column);
+            return node;
         }
         // not an assignment, rewind so expression parsing sees the identifier
         --pos;
@@ -217,8 +282,12 @@ std::unique_ptr<Stmt> Parser::parseSingleStatement() {
 
     // Fallback: expression statement
     auto expr = parseExpression();
+    size_t line = expr ? expr->getLine() : 0;
+    size_t column = expr ? expr->getColumn() : 0;
     match(TokenType::Semicolon);
-    return std::make_unique<ExprStmt>(std::move(expr));
+    auto node = std::make_unique<ExprStmt>(std::move(expr));
+    node->setLocation(line, column);
+    return node;
 }
 
 std::unique_ptr<Expr> Parser::parseExpression() {
@@ -229,11 +298,17 @@ std::unique_ptr<Expr> Parser::parseLogic() {
     auto lhs = parseEquality();
     while (true) {
         if (match(TokenType::KeywordAnd) || match(TokenType::AmpAmp)) {
+            Token op = tokens[pos-1];
             auto rhs = parseEquality();
-            lhs = std::make_unique<BinaryExpr>('&', std::move(lhs), std::move(rhs));
+            auto node = std::make_unique<BinaryExpr>('&', std::move(lhs), std::move(rhs));
+            node->setLocation(op.line, op.column);
+            lhs = std::move(node);
         } else if (match(TokenType::KeywordOr) || match(TokenType::PipePipe)) {
+            Token op = tokens[pos-1];
             auto rhs = parseEquality();
-            lhs = std::make_unique<BinaryExpr>('|', std::move(lhs), std::move(rhs));
+            auto node = std::make_unique<BinaryExpr>('|', std::move(lhs), std::move(rhs));
+            node->setLocation(op.line, op.column);
+            lhs = std::move(node);
         } else {
             break;
         }
@@ -245,11 +320,17 @@ std::unique_ptr<Expr> Parser::parseEquality() {
     auto lhs = parseComparison();
     while (true) {
         if (match(TokenType::EqualEqual)) {
+            Token op = tokens[pos-1];
             auto rhs = parseComparison();
-            lhs = std::make_unique<BinaryExpr>('s', std::move(lhs), std::move(rhs));
+            auto node = std::make_unique<BinaryExpr>('s', std::move(lhs), std::move(rhs));
+            node->setLocation(op.line, op.column);
+            lhs = std::move(node);
         } else if (match(TokenType::BangEqual)) {
+            Token op = tokens[pos-1];
             auto rhs = parseComparison();
-            lhs = std::make_unique<BinaryExpr>('d', std::move(lhs), std::move(rhs));
+            auto node = std::make_unique<BinaryExpr>('d', std::move(lhs), std::move(rhs));
+            node->setLocation(op.line, op.column);
+            lhs = std::move(node);
         } else {
             break;
         }
@@ -261,17 +342,29 @@ std::unique_ptr<Expr> Parser::parseComparison() {
     auto lhs = parseAdd();
     while (true) {
         if (match(TokenType::Less)) {
+            Token op = tokens[pos-1];
             auto rhs = parseAdd();
-            lhs = std::make_unique<BinaryExpr>('<', std::move(lhs), std::move(rhs));
+            auto node = std::make_unique<BinaryExpr>('<', std::move(lhs), std::move(rhs));
+            node->setLocation(op.line, op.column);
+            lhs = std::move(node);
         } else if (match(TokenType::LessEqual)) {
+            Token op = tokens[pos-1];
             auto rhs = parseAdd();
-            lhs = std::make_unique<BinaryExpr>('l', std::move(lhs), std::move(rhs));
+            auto node = std::make_unique<BinaryExpr>('l', std::move(lhs), std::move(rhs));
+            node->setLocation(op.line, op.column);
+            lhs = std::move(node);
         } else if (match(TokenType::Greater)) {
+            Token op = tokens[pos-1];
             auto rhs = parseAdd();
-            lhs = std::make_unique<BinaryExpr>('>', std::move(lhs), std::move(rhs));
+            auto node = std::make_unique<BinaryExpr>('>', std::move(lhs), std::move(rhs));
+            node->setLocation(op.line, op.column);
+            lhs = std::move(node);
         } else if (match(TokenType::GreaterEqual)) {
+            Token op = tokens[pos-1];
             auto rhs = parseAdd();
-            lhs = std::make_unique<BinaryExpr>('g', std::move(lhs), std::move(rhs));
+            auto node = std::make_unique<BinaryExpr>('g', std::move(lhs), std::move(rhs));
+            node->setLocation(op.line, op.column);
+            lhs = std::move(node);
         } else {
             break;
         }
@@ -283,11 +376,17 @@ std::unique_ptr<Expr> Parser::parseAdd() {
     auto lhs = parseTerm();
     while (true) {
         if (match(TokenType::Plus)) {
+            Token op = tokens[pos-1];
             auto rhs = parseTerm();
-            lhs = std::make_unique<BinaryExpr>('+', std::move(lhs), std::move(rhs));
+            auto node = std::make_unique<BinaryExpr>('+', std::move(lhs), std::move(rhs));
+            node->setLocation(op.line, op.column);
+            lhs = std::move(node);
         } else if (match(TokenType::Minus)) {
+            Token op = tokens[pos-1];
             auto rhs = parseTerm();
-            lhs = std::make_unique<BinaryExpr>('-', std::move(lhs), std::move(rhs));
+            auto node = std::make_unique<BinaryExpr>('-', std::move(lhs), std::move(rhs));
+            node->setLocation(op.line, op.column);
+            lhs = std::move(node);
         } else {
             break;
         }
@@ -299,14 +398,23 @@ std::unique_ptr<Expr> Parser::parseTerm() {
     auto lhs = parsePower();
     while (true) {
         if (match(TokenType::Star)) {
+            Token op = tokens[pos-1];
             auto rhs = parsePower();
-            lhs = std::make_unique<BinaryExpr>('*', std::move(lhs), std::move(rhs));
+            auto node = std::make_unique<BinaryExpr>('*', std::move(lhs), std::move(rhs));
+            node->setLocation(op.line, op.column);
+            lhs = std::move(node);
         } else if (match(TokenType::Slash)) {
+            Token op = tokens[pos-1];
             auto rhs = parsePower();
-            lhs = std::make_unique<BinaryExpr>('/', std::move(lhs), std::move(rhs));
+            auto node = std::make_unique<BinaryExpr>('/', std::move(lhs), std::move(rhs));
+            node->setLocation(op.line, op.column);
+            lhs = std::move(node);
         } else if (match(TokenType::Percent)) {
+            Token op = tokens[pos-1];
             auto rhs = parsePower();
-            lhs = std::make_unique<BinaryExpr>('%', std::move(lhs), std::move(rhs));
+            auto node = std::make_unique<BinaryExpr>('%', std::move(lhs), std::move(rhs));
+            node->setLocation(op.line, op.column);
+            lhs = std::move(node);
         } else {
             break;
         }
@@ -317,39 +425,62 @@ std::unique_ptr<Expr> Parser::parseTerm() {
 std::unique_ptr<Expr> Parser::parsePower() {
     auto lhs = parseFactor();
     while (match(TokenType::Caret)) {
+        Token op = tokens[pos-1];
         auto rhs = parseFactor();
-        lhs = std::make_unique<BinaryExpr>('^', std::move(lhs), std::move(rhs));
+        auto node = std::make_unique<BinaryExpr>('^', std::move(lhs), std::move(rhs));
+        node->setLocation(op.line, op.column);
+        lhs = std::move(node);
     }
     return lhs;
 }
 
 std::unique_ptr<Expr> Parser::parseFactor() {
     if (match(TokenType::Minus)) {
+        Token tok = tokens[pos-1];
         auto e = parseFactor();
-        return std::make_unique<UnaryExpr>('-', std::move(e));
+        auto node = std::make_unique<UnaryExpr>('-', std::move(e));
+        node->setLocation(tok.line, tok.column);
+        return node;
     }
     if (match(TokenType::Plus)) {
+        Token tok = tokens[pos-1];
         auto e = parseFactor();
-        return std::make_unique<UnaryExpr>('+', std::move(e));
+        auto node = std::make_unique<UnaryExpr>('+', std::move(e));
+        node->setLocation(tok.line, tok.column);
+        return node;
     }
     if (match(TokenType::KeywordNot) || match(TokenType::Bang)) {
+        Token tok = tokens[pos-1];
         auto e = parseFactor();
-        return std::make_unique<UnaryExpr>('!', std::move(e));
+        auto node = std::make_unique<UnaryExpr>('!', std::move(e));
+        node->setLocation(tok.line, tok.column);
+        return node;
     }
     if (match(TokenType::Number)) {
-        return std::make_unique<NumberExpr>(std::stol(tokens[pos-1].text));
+        Token tok = tokens[pos-1];
+        auto node = std::make_unique<NumberExpr>(std::stol(tok.text));
+        node->setLocation(tok.line, tok.column);
+        return node;
     }
     if (match(TokenType::String)) {
-        return std::make_unique<StringExpr>(tokens[pos-1].text);
+        Token tok = tokens[pos-1];
+        auto node = std::make_unique<StringExpr>(tok.text);
+        node->setLocation(tok.line, tok.column);
+        return node;
     }
     if (match(TokenType::Identifier)) {
-        std::string name = tokens[pos-1].text;
+        Token idTok = tokens[pos-1];
+        std::string name = idTok.text;
         if (match(TokenType::LParen)) {
             auto args = parseArguments();
             match(TokenType::RParen);
-            return std::make_unique<CallExpr>(name, std::move(args));
+            auto node = std::make_unique<CallExpr>(name, std::move(args));
+            node->setLocation(idTok.line, idTok.column);
+            return node;
         }
-        return std::make_unique<VariableExpr>(name);
+        auto node = std::make_unique<VariableExpr>(name);
+        node->setLocation(idTok.line, idTok.column);
+        return node;
     }
     if (match(TokenType::LParen)) {
         auto expr = parseExpression();

--- a/tests/unittests/test_compiler.cpp
+++ b/tests/unittests/test_compiler.cpp
@@ -122,7 +122,7 @@ TEST(CodeGenTest, GeneratesAssembly) {
 TEST(InterpreterTest, BuiltinPrintFloat) {
     Interpreter interp;
     testing::internal::CaptureStdout();
-    interp.callFunction(BUILTIN_PRINT, {Value::Float(3.14)});
+    interp.callFunction(BUILTIN_PRINT, {Value::Float(3.14)}, 0, 0);
     std::string output = testing::internal::GetCapturedStdout();
     EXPECT_EQ(output, std::string("3.14\n"));
 }
@@ -130,23 +130,23 @@ TEST(InterpreterTest, BuiltinPrintFloat) {
 TEST(InterpreterTest, BuiltinPrintBool) {
     Interpreter interp;
     testing::internal::CaptureStdout();
-    interp.callFunction(BUILTIN_PRINT, {Value::Bool(true)});
-    interp.callFunction(BUILTIN_PRINT, {Value::Bool(false)});
+    interp.callFunction(BUILTIN_PRINT, {Value::Bool(true)}, 0, 0);
+    interp.callFunction(BUILTIN_PRINT, {Value::Bool(false)}, 0, 0);
     std::string output = testing::internal::GetCapturedStdout();
     EXPECT_EQ(output, std::string("cheka\njaniwa\n"));
 }
 
 TEST(InterpreterTest, BuiltinArrayLength) {
     Interpreter interp;
-    auto handle = interp.callFunction(BUILTIN_ARRAY_NEW, {Value::Int(5)});
-    auto len = interp.callFunction(BUILTIN_ARRAY_LENGTH, {handle});
+    auto handle = interp.callFunction(BUILTIN_ARRAY_NEW, {Value::Int(5)}, 0, 0);
+    auto len = interp.callFunction(BUILTIN_ARRAY_LENGTH, {handle}, 0, 0);
     EXPECT_EQ(len.i, 5);
-    interp.callFunction(BUILTIN_ARRAY_FREE, {handle});
+    interp.callFunction(BUILTIN_ARRAY_FREE, {handle}, 0, 0);
 }
 
 TEST(InterpreterTest, LookupUndefinedVariableThrows) {
     Interpreter interp;
-    EXPECT_THROW(interp.lookup("missing"), std::runtime_error);
+    EXPECT_THROW(interp.lookup("missing", 0, 0), std::runtime_error);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## Summary
- track line and column on all AST nodes
- surface source locations in interpreter runtime errors
- parser populates node locations during AST construction

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c822c08eb48327ac38dbe2980240c2