### PR TITLE
Handle negative array indices safely

### DIFF
--- a/compiler/interpreter/interpreter.cpp
+++ b/compiler/interpreter/interpreter.cpp
@@ -132,8 +132,11 @@ Value Interpreter::callFunction(const std::string &name, const std::vector<Value
                     auto &arr = this->arrays[idx];
                     if (index >= 0 && static_cast<size_t>(index) < arr.size()) {
                         return Value::Int(arr[static_cast<size_t>(index)]);
+                    } else {
+                        throw std::runtime_error("array index out of bounds at line " +
+                                               std::to_string(line) + ", column " +
+                                               std::to_string(column));
                     }
-                    return Value::Int(0);
                 }
             }
         }

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -53,7 +53,11 @@ long aym_array_get(intptr_t arr, long idx) {
     if (!arr) return 0;
     long *a = (long*)arr;
     long len = *(a - 1);
-    if (idx < 0 || idx >= len) return 0;
+    if (idx < 0) {
+        fprintf(stderr, "aym_array_get: negative index %ld\n", idx);
+        return 0; // default value on error
+    }
+    if (idx >= len) return 0;
     return a[idx];
 }
 
@@ -61,7 +65,11 @@ long aym_array_set(intptr_t arr, long idx, long val) {
     if (!arr) return 0;
     long *a = (long*)arr;
     long len = *(a - 1);
-    if (idx < 0 || idx >= len) return 0;
+    if (idx < 0) {
+        fprintf(stderr, "aym_array_set: negative index %ld\n", idx);
+        return 0; // indicate error
+    }
+    if (idx >= len) return 0;
     a[idx] = val;
     return val;
 }

--- a/tests/unittests/test_compiler.cpp
+++ b/tests/unittests/test_compiler.cpp
@@ -144,6 +144,15 @@ TEST(InterpreterTest, BuiltinArrayLength) {
     interp.callFunction(BUILTIN_ARRAY_FREE, {handle}, 0, 0);
 }
 
+TEST(InterpreterTest, ArrayGetNegativeIndexThrows) {
+    Interpreter interp;
+    auto handle = interp.callFunction(BUILTIN_ARRAY_NEW, {Value::Int(3)}, 0, 0);
+    EXPECT_THROW(interp.callFunction(BUILTIN_ARRAY_GET,
+                                    {handle, Value::Int(-1)}, 1, 1),
+                 std::runtime_error);
+    interp.callFunction(BUILTIN_ARRAY_FREE, {handle}, 0, 0);
+}
+
 TEST(InterpreterTest, LookupUndefinedVariableThrows) {
     Interpreter interp;
     EXPECT_THROW(interp.lookup("missing", 0, 0), std::runtime_error);


### PR DESCRIPTION
## Summary
- guard runtime array operations against negative indices and return a safe default
- throw on invalid indices in interpreter array_get so user code sees the error
- add unit test covering negative index access

## Testing
- `./tests/unittests/test_compiler`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c82770857c8327aa0e4fb1acbf5ff7