### PR TITLE
Add deterministic random seed option

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,17 @@ $ ./bin/aymc --windows samples/hola.aym
 $ ./bin/aymc --linux samples/hola.aym
 ```
 
+### Semilla de números aleatorios
+
+El compilador acepta `--seed <valor>` para fijar la semilla del generador de
+números aleatorios tanto en el intérprete como en los ejecutables generados.
+Esto permite reproducir secuencias de `random()` de manera determinista.
+
+```bash
+$ ./bin/aymc --seed 42 samples/random.aym
+$ ./bin/random
+```
+
 ### Uso en Windows
 
 1. Instalar [MinGW-w64](https://www.mingw-w64.org/) (GCC 9 o superior) y la versión para Windows de `nasm`.

--- a/compiler/codegen/codegen.h
+++ b/compiler/codegen/codegen.h
@@ -18,7 +18,8 @@ public:
                   const std::unordered_set<std::string> &globals,
                   const std::unordered_map<std::string, std::vector<std::string>> &paramTypes,
                   const std::unordered_map<std::string, std::string> &globalTypes,
-                  bool windows);
+                  bool windows,
+                  long seed);
 };
 
 } // namespace aym

--- a/compiler/interpreter/interpreter.cpp
+++ b/compiler/interpreter/interpreter.cpp
@@ -12,6 +12,15 @@ namespace aym {
 
 Interpreter::Interpreter() = default;
 
+Interpreter::Interpreter(unsigned int seed) {
+    setSeed(seed);
+}
+
+void Interpreter::setSeed(unsigned int seed) {
+    std::srand(seed);
+    randSeeded = true;
+}
+
 void Interpreter::pushScope() {
     scopes.emplace_back();
 }
@@ -90,10 +99,9 @@ Value Interpreter::callFunction(const std::string &name, const std::vector<Value
         return Value::Int(0);
     }
     if (name == BUILTIN_RANDOM) {
-        static bool seeded = false;
-        if (!seeded) {
+        if (!randSeeded) {
             std::srand(std::time(nullptr));
-            seeded = true;
+            randSeeded = true;
         }
         if (!args.empty() && args[0].i > 0) {
             return Value::Int(std::rand() % args[0].i);

--- a/compiler/interpreter/interpreter.h
+++ b/compiler/interpreter/interpreter.h
@@ -26,6 +26,8 @@ struct Value {
 class Interpreter : public ASTVisitor {
 public:
     Interpreter();
+    explicit Interpreter(unsigned int seed);
+    void setSeed(unsigned int seed);
     void execute(const std::vector<std::unique_ptr<Node>> &nodes);
     Value getLastValue() const { return lastValue; }
 
@@ -53,6 +55,7 @@ public:
 
 private:
     Value lastValue;
+    bool randSeeded = false;
     bool breakFlag = false;
     bool continueFlag = false;
     bool returnFlag = false;

--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -25,6 +25,8 @@ int main(int argc, char** argv) {
 #else
         false;
 #endif
+    long seed = 0;
+    bool seedProvided = false;
 
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
@@ -44,6 +46,9 @@ int main(int argc, char** argv) {
             windowsTarget = true;
         } else if (arg == "--linux") {
             windowsTarget = false;
+        } else if (arg == "--seed" && i + 1 < argc) {
+            seed = std::stol(argv[++i]);
+            seedProvided = true;
         } else {
             inputs.push_back(arg);
         }
@@ -52,6 +57,7 @@ int main(int argc, char** argv) {
     if (repl) {
         std::cout << "AymaraLang REPL - escribe código línea por línea (escribe 'salir' para terminar)" << std::endl;
         aym::Interpreter interp;
+        if (seedProvided) interp.setSeed(static_cast<unsigned int>(seed));
         std::vector<std::unique_ptr<aym::Node>> program;
         aym::SemanticAnalyzer sem;
         std::string line;
@@ -124,7 +130,7 @@ int main(int argc, char** argv) {
     sem.analyze(nodes);
 
     aym::CodeGenerator cg;
-    cg.generate(nodes, output + ".asm", sem.getGlobals(), sem.getParamTypes(), sem.getGlobalTypes(), windowsTarget);
+    cg.generate(nodes, output + ".asm", sem.getGlobals(), sem.getParamTypes(), sem.getGlobalTypes(), windowsTarget, seedProvided ? seed : -1);
 
     return 0;
 }

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -18,11 +18,16 @@ void leer_linea(char *buf, int size) {
     }
 }
 
+static int seeded = 0;
+
+void aym_srand(unsigned int seed) {
+    srand(seed);
+    seeded = 1;
+}
+
 int aym_random(int max) {
-    static int seeded = 0;
     if (!seeded) {
-        srand((unsigned)time(NULL));
-        seeded = 1;
+        aym_srand((unsigned)time(NULL));
     }
     if (max > 0) return rand() % max;
     return rand();

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -27,8 +27,10 @@ make >/dev/null
 ./bin/aymc samples/negativos.aym >/dev/null
 ./bin/negativos | grep -q -- -7
 
-./bin/aymc samples/random.aym >/dev/null
-./bin/random >/dev/null
+./bin/aymc --seed 1 samples/random.aym >/dev/null
+out1=$(./bin/random)
+out2=$(./bin/random)
+[ "$out1" = "$out2" ]
 
 ./bin/aymc samples/array_length.aym >/dev/null
 ./bin/array_length | grep -q -- 3

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -26,8 +26,10 @@ run string Kamisaraki
 run range_for 3
 run negativos -7
 run array_length 3
-./bin/aymc samples/random.aym >/dev/null
-./bin/random >/dev/null
+./bin/aymc --seed 1 samples/random.aym >/dev/null
+out1=$(./bin/random)
+out2=$(./bin/random)
+[ "$out1" = "$out2" ]
 
 ./bin/aymc samples/calculadora.aym >/dev/null
 printf "3\n4\n" | ./bin/calculadora | grep -q 7


### PR DESCRIPTION
## Summary
- allow passing `--seed` to the compiler
- seed interpreter and runtime random generators for deterministic output
- document and test the new `--seed` flag

## Testing
- `./tests/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c82ffd6aa08327885a59ad8e6645b1