### PR TITLE
Improve parser error recovery and tests

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -26,6 +26,16 @@ void Parser::parseError(const std::string &msg) {
     std::cerr << "[parser] Error en linea " << tok.line << ", columna " << tok.column
               << ": " << msg << std::endl;
     hadError = true;
+    synchronize();
+}
+
+void Parser::synchronize() {
+    while (pos < tokens.size()) {
+        TokenType t = peek().type;
+        if (t == TokenType::Semicolon) { get(); break; }
+        if (t == TokenType::RBrace || t == TokenType::EndOfFile) break;
+        get();
+    }
 }
 
 void Parser::parseStatements(std::vector<std::unique_ptr<Stmt>> &nodes, bool stopAtBrace) {
@@ -488,7 +498,6 @@ std::unique_ptr<Expr> Parser::parseFactor() {
         return expr;
     }
     parseError("token inesperado");
-    get();
     return nullptr;
 }
 

--- a/compiler/parser/parser.h
+++ b/compiler/parser/parser.h
@@ -25,6 +25,7 @@ private:
     const Token &get();
     bool match(TokenType type);
     void parseError(const std::string &msg);
+    void synchronize();
     void parseStatements(std::vector<std::unique_ptr<Stmt>> &nodes, bool stopAtBrace = false);
     std::unique_ptr<Stmt> parseSingleStatement();
     std::unique_ptr<Expr> parseExpression();


### PR DESCRIPTION
## Summary
- synchronize parser on semicolons and closing braces after syntax errors
- handle unexpected tokens without losing statements
- cover error recovery with new parser test and update codegen test to create build directories

## Testing
- `g++ -std=c++17 -I. tests/unittests/test_compiler.cpp $(find compiler -name '*.cpp' ! -name 'main.cpp') -lgtest -lgtest_main -pthread -o /tmp/test_compiler`
- `/tmp/test_compiler`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c83267142883278d0a27e41b5477a0