### PR TITLE
Add macOS build guide and sample Makefile

### DIFF
--- a/Makefile.macos
+++ b/Makefile.macos
@@ -1,0 +1,43 @@
+# Makefile de referencia para compilar AymaraLang (aymc) en macOS
+# Usa clang++ y la libc++ proporcionada por Apple/Homebrew.
+
+CXX ?= clang++
+CXXFLAGS ?= -std=c++17 -Wall -Wextra -O2
+LDFLAGS ?=
+
+SRC_DIR := compiler
+BUILD_DIR := build
+BIN_DIR := bin
+
+MAIN_SRC := $(SRC_DIR)/main.cpp
+LEXER_SRC := $(wildcard $(SRC_DIR)/lexer/*.cpp)
+PARSER_SRC := $(wildcard $(SRC_DIR)/parser/*.cpp)
+AST_SRC := $(wildcard $(SRC_DIR)/ast/*.cpp)
+CODEGEN_SRC := $(wildcard $(SRC_DIR)/codegen/*.cpp)
+UTILS_SRC := $(SRC_DIR)/utils/utils.cpp
+MODULE_RESOLVER_SRC := $(SRC_DIR)/utils/module_resolver.cpp
+ERROR_SRC := $(SRC_DIR)/utils/error.cpp
+SEMANTIC_SRC := $(wildcard $(SRC_DIR)/semantic/*.cpp)
+BUILTINS_SRC := $(wildcard $(SRC_DIR)/builtins/*.cpp)
+INTERPRETER_SRC := $(wildcard $(SRC_DIR)/interpreter/*.cpp)
+
+SRCS := $(MAIN_SRC) $(LEXER_SRC) $(PARSER_SRC) $(AST_SRC) $(CODEGEN_SRC) \
+        $(UTILS_SRC) $(MODULE_RESOLVER_SRC) $(ERROR_SRC) $(SEMANTIC_SRC) \
+        $(BUILTINS_SRC) $(INTERPRETER_SRC)
+
+OBJS := $(patsubst $(SRC_DIR)/%.cpp,$(BUILD_DIR)/%.o,$(SRCS))
+
+.PHONY: all clean
+
+all: $(BIN_DIR)/aymc
+
+$(BIN_DIR)/aymc: $(OBJS)
+	@mkdir -p $(BIN_DIR)
+	$(CXX) $(CXXFLAGS) $^ -o $@ $(LDFLAGS)
+
+$(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(BUILD_DIR) $(BIN_DIR)/aymc

--- a/README.md
+++ b/README.md
@@ -182,6 +182,57 @@ inicio
 1
 ```
 
+## 🛠️ Construcción del compilador
+
+### Linux
+
+1. Dependencias: `g++` (>= 10), `make`, `nasm` y `gcc`/`ld` para el enlace final.
+2. Ejecuta `make` para compilar el binario en `bin/aymc`.
+3. (Opcional) Lanza `make test` para correr el paquete de pruebas automatizadas.
+
+### macOS
+
+1. Instala las *Command Line Tools* de Xcode:
+
+   ```bash
+   xcode-select --install
+   ```
+
+2. Instala [Homebrew](https://brew.sh/) si aún no lo tienes disponible.
+3. Con Homebrew, instala las dependencias necesarias:
+
+   ```bash
+   brew install llvm nasm cmake make
+   ```
+
+4. Asegura que el `clang++` de Homebrew esté en tu `PATH` (ajusta la ruta según Apple Silicon `/opt/homebrew` o Intel `/usr/local`):
+
+   ```bash
+   export PATH="$(brew --prefix llvm)/bin:$PATH"
+   export LDFLAGS="-L$(brew --prefix llvm)/lib"
+   export CPPFLAGS="-I$(brew --prefix llvm)/include"
+   ```
+
+5. Compila el proyecto usando el *Makefile* específico para macOS:
+
+   ```bash
+   make -f Makefile.macos
+   ```
+
+   El binario `bin/aymc` quedará listo para compilar programas `.aym` (los ejecutables generados siguen siendo ELF o PE según el modo seleccionado).
+6. Como alternativa, puedes usar CMake con `clang++`:
+
+   ```bash
+   cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++
+   cmake --build build -j
+   ```
+
+### Windows (resumen)
+
+1. Instala [MinGW-w64](https://www.mingw-w64.org/) (GCC 9 o superior) y `nasm` para Windows.
+2. Ejecuta `build.bat` desde la terminal de MinGW para generar `aymc.exe`.
+3. Consulta la sección [**Uso en Windows**](#uso-en-windows) para más detalles sobre la ejecución.
+
 ### Selección de plataforma
 
 `aymc` permite elegir el sistema operativo de destino. De forma predeterminada se


### PR DESCRIPTION
## Summary
- document Linux, macOS, and Windows build steps in the README, including macOS prerequisites and command examples
- add a dedicated `Makefile.macos` that builds the compiler with clang++ for Apple environments

## Testing
- `CXX=clang++ make -f Makefile.macos -j2`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c8415314e48327a78e779238aca391