### PR TITLE
Allow building without LLVM dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(aymaraLang CXX C)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+option(AYM_ENABLE_LLVM "Enable LLVM backend" ON)
+
 if(MSVC)
   add_compile_options(/W4 /permissive-)
   add_compile_options($<$<CONFIG:Release>:/O2>)
@@ -18,15 +20,21 @@ file(GLOB_RECURSE AYM_SOURCES CONFIGURE_DEPENDS
 
 add_executable(aymc ${AYM_SOURCES})
 
-find_package(LLVM REQUIRED CONFIG)
-message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-
-set(AYM_LLVM_COMPONENTS core support)
-llvm_map_components_to_libnames(AYM_LLVM_LIBS ${AYM_LLVM_COMPONENTS})
-
-target_include_directories(aymc PRIVATE ${LLVM_INCLUDE_DIRS})
-target_compile_definitions(aymc PRIVATE ${LLVM_DEFINITIONS})
-target_link_libraries(aymc PRIVATE ${AYM_LLVM_LIBS})
+if(AYM_ENABLE_LLVM)
+  find_package(LLVM QUIET CONFIG)
+  if(LLVM_FOUND)
+    message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+    set(AYM_LLVM_COMPONENTS core support)
+    llvm_map_components_to_libnames(AYM_LLVM_LIBS ${AYM_LLVM_COMPONENTS})
+    target_include_directories(aymc PRIVATE ${LLVM_INCLUDE_DIRS})
+    target_compile_definitions(aymc PRIVATE ${LLVM_DEFINITIONS} AYM_WITH_LLVM)
+    target_link_libraries(aymc PRIVATE ${AYM_LLVM_LIBS})
+  else()
+    message(WARNING "LLVM solicitado pero no encontrado; compilando sin backend LLVM.")
+  endif()
+else()
+  message(STATUS "LLVM backend deshabilitado mediante AYM_ENABLE_LLVM=OFF")
+endif()
 
 # Put binaries into bin/ inside the build directory
 set_target_properties(aymc PROPERTIES

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,31 @@ CXXFLAGS ?= -std=c++17 -Wall -Wextra -O2
 LDFLAGS ?=
 
 LLVM_CONFIG ?= llvm-config
-LLVM_CXXFLAGS := $(shell $(LLVM_CONFIG) --cxxflags 2>/dev/null)
-LLVM_LDFLAGS := $(shell $(LLVM_CONFIG) --ldflags --libs core support 2>/dev/null)
+
+ifeq ($(OS),Windows_NT)
+LLVM_FOUND := $(shell where $(LLVM_CONFIG) 2>nul)
+else
+LLVM_FOUND := $(shell command -v $(LLVM_CONFIG) 2>/dev/null)
+endif
+
+ifeq ($(strip $(LLVM_FOUND)),)
+LLVM_ENABLED := 0
+LLVM_CXXFLAGS :=
+LLVM_LDFLAGS :=
+else
+LLVM_ENABLED := 1
+LLVM_CXXFLAGS := $(shell $(LLVM_CONFIG) --cxxflags)
+LLVM_LDFLAGS := $(shell $(LLVM_CONFIG) --ldflags --libs core support)
+endif
 
 CXXFLAGS += $(LLVM_CXXFLAGS)
 LDFLAGS += $(LLVM_LDFLAGS)
+
+ifeq ($(LLVM_ENABLED),1)
+CXXFLAGS += -DAYM_WITH_LLVM
+else
+$(info LLVM backend deshabilitado (llvm-config no encontrado); construyendo sin soporte LLVM)
+endif
 
 SRC_DIR := compiler
 BUILD_DIR := build
@@ -41,8 +61,8 @@ OBJS := $(patsubst $(SRC_DIR)/%.cpp,$(BUILD_DIR)/%.o,$(SRCS))
 all: $(BIN_DIR)/aymc
 
 $(BIN_DIR)/aymc: $(OBJS)
-        @mkdir -p $(BIN_DIR)
-        $(CXX) $(CXXFLAGS) $^ -o $@ $(LDFLAGS)
+	@mkdir -p $(BIN_DIR)
+	$(CXX) $(CXXFLAGS) $^ -o $@ $(LDFLAGS)
 
 # Pattern rule: compile any compiler/*.cpp to build/*.o
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp

--- a/build.bat
+++ b/build.bat
@@ -3,11 +3,20 @@ REM Build script for AymaraLang compiler using MinGW-w64 and NASM
 if not exist build mkdir build
 if not exist bin mkdir bin
 
-set LLVM_CONFIG=llvm-config
-for /f "delims=" %%i in ('%LLVM_CONFIG% --cxxflags') do set LLVM_CXXFLAGS=%%i
-for /f "delims=" %%i in ('%LLVM_CONFIG% --ldflags --libs core support') do set LLVM_LDFLAGS=%%i
+set "LLVM_CONFIG=llvm-config"
+where %LLVM_CONFIG% >nul 2>nul
+if %errorlevel%==0 (
+  for /f "delims=" %%i in ('%LLVM_CONFIG% --cxxflags') do set "LLVM_CXXFLAGS=%%i"
+  for /f "delims=" %%i in ('%LLVM_CONFIG% --ldflags --libs core support') do set "LLVM_LDFLAGS=%%i"
+  set "LLVM_DEFINE=-DAYM_WITH_LLVM"
+) else (
+  echo LLVM backend deshabilitado (llvm-config no encontrado); construyendo sin soporte LLVM.
+  set "LLVM_CXXFLAGS="
+  set "LLVM_LDFLAGS="
+  set "LLVM_DEFINE="
+)
 
-g++ -std=c++17 -Wall -O2 %LLVM_CXXFLAGS% ^
+g++ -std=c++17 -Wall -O2 %LLVM_CXXFLAGS% %LLVM_DEFINE% ^
   compiler\ast\ast.cpp ^
   compiler\builtins\builtins.cpp ^
   compiler\codegen\codegen.cpp ^

--- a/compiler/codegen/llvm/llvm_codegen.cpp
+++ b/compiler/codegen/llvm/llvm_codegen.cpp
@@ -2,6 +2,8 @@
 
 #include "../../ast/ast.h"
 
+#ifdef AYM_WITH_LLVM
+
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
@@ -88,3 +90,28 @@ void LLVMCodeGenerator::generate(const std::vector<std::unique_ptr<Node>> &nodes
 }
 
 } // namespace aym
+
+#else // !AYM_WITH_LLVM
+
+#include "../../utils/error.h"
+
+namespace aym {
+
+void LLVMCodeGenerator::generate(const std::vector<std::unique_ptr<Node>> &nodes,
+                                 const std::string &outputPath,
+                                 const std::unordered_set<std::string> &globals,
+                                 const std::unordered_map<std::string, std::vector<std::string>> &paramTypes,
+                                 const std::unordered_map<std::string, std::string> &globalTypes,
+                                 long seed) {
+    (void)nodes;
+    (void)outputPath;
+    (void)globals;
+    (void)paramTypes;
+    (void)globalTypes;
+    (void)seed;
+    error("El backend LLVM no está disponible en esta compilación. Recompila con soporte de LLVM.");
+}
+
+} // namespace aym
+
+#endif


### PR DESCRIPTION
## Summary
- guard the LLVM backend usage in the compiler so the binary builds without LLVM installed
- auto-detect llvm-config in Makefile, Windows build script, and CMake, enabling the backend only when available
- provide a graceful runtime error when --llvm is requested without LLVM support

## Testing
- make
- make test

------
https://chatgpt.com/codex/tasks/task_e_68c85f1c92548327976443a4f121d5c3