### PR TITLE
Fix Windows build script echo syntax

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -10,7 +10,7 @@ if %errorlevel%==0 (
   for /f "delims=" %%i in ('%LLVM_CONFIG% --ldflags --libs core support') do set "LLVM_LDFLAGS=%%i"
   set "LLVM_DEFINE=-DAYM_WITH_LLVM"
 ) else (
-  echo LLVM backend deshabilitado (llvm-config no encontrado); construyendo sin soporte LLVM.
+  echo LLVM backend deshabilitado ^(llvm-config no encontrado^); construyendo sin soporte LLVM.
   set "LLVM_CXXFLAGS="
   set "LLVM_LDFLAGS="
   set "LLVM_DEFINE="


### PR DESCRIPTION
## Summary
- escape the parentheses in the LLVM warning message of `build.bat`
- prevent Windows batch syntax errors when llvm-config is absent

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68c8a6b41c808327b80fae84b28a339a