### PR TITLE
Include module resolver in Windows build script

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -25,6 +25,7 @@ g++ -std=c++17 -Wall -O2 %LLVM_CXXFLAGS% %LLVM_DEFINE% ^
   compiler\parser\parser.cpp ^
   compiler\semantic\semantic.cpp ^
   compiler\utils\utils.cpp ^
+  compiler\utils\module_resolver.cpp ^
   compiler\utils\error.cpp ^
   compiler\interpreter\interpreter.cpp ^
   compiler\main.cpp ^


### PR DESCRIPTION
## Summary
- add the missing module_resolver.cpp translation unit to the Windows build script so ModuleResolver symbols are linked

## Testing
- make test


------
https://chatgpt.com/codex/tasks/task_e_68c8abfe86cc8327aff7a1a1fa39e9fc