### PR TITLE
Include runtime in deb package and prefer packaged runtime at runtime lookup

### DIFF
--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -162,9 +162,15 @@ int main(int argc, char** argv) {
     (void)useLLVMBackend; // suprimir advertencias cuando LLVM está deshabilitado
 #endif
 
-    fs::path runtimeDir = fs::path(aym::executableDir()) / "runtime";
+    fs::path exeDir = fs::path(aym::executableDir());
+    fs::path runtimeDir = exeDir / "runtime";
     if (!fs::exists(runtimeDir)) {
-        runtimeDir = fs::path("runtime");
+        fs::path sharedRuntime = exeDir / ".." / "share" / "aymaraLang" / "runtime";
+        if (fs::exists(sharedRuntime)) {
+            runtimeDir = sharedRuntime;
+        } else {
+            runtimeDir = fs::path("runtime");
+        }
     }
 
     aym::CodeGenerator cg;

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -31,6 +31,17 @@ if [ ! -f "${ICON_FILE}" ]; then
   echo "No se encontró ${ICON_FILE}. Verifica el icono en assets/." >&2
   exit 1
 fi
+RUNTIME_SRC_DIR="${ROOT_DIR}/runtime"
+RUNTIME_DIST_DIR="${DIST_DIR}/share/aymaraLang/runtime"
+if [ ! -d "${RUNTIME_DIST_DIR}" ]; then
+  if [ ! -d "${RUNTIME_SRC_DIR}" ]; then
+    echo "No se encontró ${RUNTIME_SRC_DIR}. Verifica los archivos runtime." >&2
+    exit 1
+  fi
+  echo "No se encontró runtime en dist. Copiando ${RUNTIME_SRC_DIR} a ${RUNTIME_DIST_DIR}..."
+  mkdir -p "${RUNTIME_DIST_DIR}"
+  cp -R "${RUNTIME_SRC_DIR}/." "${RUNTIME_DIST_DIR}/"
+fi
 
 VERSION_FILE="${ROOT_DIR}/VERSION.txt"
 VERSION="0.1.0"


### PR DESCRIPTION
### Motivation
- Prevent runtime lookup/linker errors when `aymc` is executed from a packaged install by preferring the runtime shipped with the package.
- Ensure new users who install the `.deb` do not need a locally built runtime by packaging the repository `runtime` files into the distribution tree.

### Description
- Update `compiler/main.cpp` to compute `exeDir = aym::executableDir()` and set `runtimeDir` to `exeDir/runtime`, falling back to `exeDir/../share/aymaraLang/runtime` when present and finally to the project-local `runtime` directory.
- Pass the resolved `runtimeDir.string()` into `aym::CodeGenerator::generate` so the generator uses the preferred runtime path at runtime.
- Update `scripts/build_deb.sh` to copy the repository `runtime` directory into `dist/share/aymaraLang/runtime` when that runtime is missing from `dist`, creating the destination directory and erroring if source `runtime` is absent.
- Keep existing packaging layout under `opt/aymaralang` and add the runtime into the distribution prefix so the resulting `.deb` is self-contained for runtime sources.

### Testing
- No automated tests were executed for these changes.
- The updated `scripts/build_deb.sh` was committed and the package-related script changes were validated via a repository update (no build or package creation was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69838bc3a59c8327894fdbf80b63f1a5)